### PR TITLE
fix(error-status-codes): set 500 status code on unknown errors

### DIFF
--- a/src/api/desktop/recent-saves/index.ts
+++ b/src/api/desktop/recent-saves/index.ts
@@ -51,7 +51,7 @@ router
           },
         ],
       };
-      res.json(errorResponse);
+      res.status(500).json(errorResponse);
       return;
     }
   });


### PR DESCRIPTION
This is an oversight discovered talking with the client team.

## Goal
Set 500 status code for errors that the proxy is not equipped to handle.

## I'd love feedback/perspectives on:
N/A

## Implementation Decisions
N/A

## Deployment steps
N/A

## References

JIRA ticket:
This still isn't seeing production use. No client or customer impact to track. Just getting a fix in.
