### PR TITLE
chore(auth-bugs): authentication maintenance, bugfixes

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1,7 +1,7 @@
 openapi: '3.0.3'
 info:
   title: Firefox API Proxy
-  version: '0.2'
+  version: '0.3'
   license:
     name: ISC
     url: https://opensource.org/licenses/ISC
@@ -154,11 +154,6 @@ components:
   securitySchemes:
     # The following schemes prefixed with "WS" all constitute a `WebSession` auth.
     # These are all required together for requests that require this auth type.
-    WSSessionGuidAuth:
-      type: apiKey
-      in: cookie
-      name: sess_guid
-      description: A portion of `WebSession` legacy auth.
     WSUserAuth:
       type: apiKey
       in: cookie
@@ -174,12 +169,24 @@ components:
       in: cookie
       name: 159e76e
       description: A portion of `WebSession` legacy auth. Session lookup.
-    # this is usually transmitted via query params in web V3, tentatively move to headers
     WSConsumerKeyAuth:
+      type: apiKey
+      in: query
+      name: consumer_key
+      description: A portion of `WebSession` legacy auth.
+    # Originally tried to support this via headers and will continue to support
+    # this alternative, however I suspect this may be causing issues. _ is not
+    # valid character in headers. Many services allow this through, and this works
+    # the overwhelming majority of the time. However, there have been client reports
+    # of rejecting requests due to missing consumer_key, and I suspect some edge case
+    # could be removing this.
+    #
+    # Avoiding confusion around renaming, and just preferring query params first.
+    WSConsumerKeyAuthAlias:
       type: apiKey
       in: header
       name: consumer_key
-      description: A portion of `WebSession` legacy auth.
+      description: A portion of `WebSession` legacy auth. This isn't actually a valid header (_ is not permitted), prefer query param.
 
 paths:
   /desktop/v1/recommendations:
@@ -189,6 +196,7 @@ paths:
       # Intentionally blank security. No auth required.
       security:
         - WSConsumerKeyAuth: []
+        - WSConsumerKeyAuthAlias: []
       parameters:
         - name: count
           in: query
@@ -266,11 +274,14 @@ paths:
       operationId: getRecentSaves
       security:
         # require all WS (WebSession) security schemes together
-        - WSSessionGuidAuth: []
-          WSUserAuth: []
+        - WSUserAuth: []
           WSSessionAuth: []
           WSLookupAuth: []
           WSConsumerKeyAuth: []
+        - WSUserAuth: []
+          WSSessionAuth: []
+          WSLookupAuth: []
+          WSConsumerKeyAuthAlias: []
       parameters:
         - name: count
           in: query

--- a/scripts/scrapeCookie.js
+++ b/scripts/scrapeCookie.js
@@ -10,7 +10,7 @@
 
 const cookie = process.argv[2];
 
-const names = new Set(['sess_guid', 'a95b4b6', 'd4a79ec', '159e76e']);
+const names = new Set(['a95b4b6', 'd4a79ec', '159e76e']);
 
 const parsed = cookie
   .split(';')

--- a/src/auth/consumerKeyHandler.spec.ts
+++ b/src/auth/consumerKeyHandler.spec.ts
@@ -16,8 +16,13 @@ app.get('/anything', (req: express.Request, res: express.Response) => {
   res.status(200).json({ yay: true });
 });
 
-const headers = {
+// both query param and header are permitted, but query param
+// is preferred
+const query = {
   consumer_key: 'someConsumerKey',
+};
+const headers = {
+  consumer_key: 'someOtherConsumerKey',
 };
 
 describe('ConsumerKeyHandler', () => {
@@ -52,11 +57,30 @@ describe('ConsumerKeyHandler', () => {
   });
 
   describe('happy path', () => {
-    it('populates consumer_key on express Request if present', async () => {
+    it('populates consumer_key on express Request if provided via headers', async () => {
       const res = await request(app).get('/anything').set(headers).send();
 
       expect(res.status).toEqual(200);
       expect(consumer_key).toEqual(headers.consumer_key);
+    });
+    it('populates consumer_key on express Request if provided via query params', async () => {
+      const res = await request(app)
+        .get(`/anything?consumer_key=${query.consumer_key}`)
+        .send();
+
+      expect(res.status).toEqual(200);
+      expect(consumer_key).toEqual(query.consumer_key);
+    });
+    it('prefers query params if both are present', async () => {
+      const res = await request(app)
+        .get(`/anything?consumer_key=${query.consumer_key}`)
+        .set({
+          ...headers,
+        })
+        .send();
+
+      expect(res.status).toEqual(200);
+      expect(consumer_key).toEqual(query.consumer_key);
     });
   });
 });

--- a/src/auth/consumerKeyHandler.ts
+++ b/src/auth/consumerKeyHandler.ts
@@ -13,15 +13,21 @@ type ErrorResponse = components['schemas']['ErrorResponse'];
 type ExpectedHeaders = {
   consumer_key?: string;
 };
+type ExpectedQueryParams = {
+  consumer_key?: string;
+};
 
 const ConsumerKeyHandler = (
   req: Request,
   res: Response,
   next: NextFunction
 ): void => {
+  // both query param and header are permitted, but query param
+  // is preferred
   const requestHeaders: ExpectedHeaders = req.headers as ExpectedHeaders;
+  const requestQuery: ExpectedQueryParams = req.query as ExpectedQueryParams;
 
-  if (!requestHeaders.consumer_key) {
+  if (!requestQuery.consumer_key && !requestHeaders.consumer_key) {
     res.status(401).json({
       errors: [
         {
@@ -36,7 +42,7 @@ const ConsumerKeyHandler = (
     return;
   }
 
-  req.consumer_key = requestHeaders.consumer_key;
+  req.consumer_key = requestQuery.consumer_key ?? requestHeaders.consumer_key;
   next();
 };
 

--- a/src/auth/web-session/webSessionAuth.spec.ts
+++ b/src/auth/web-session/webSessionAuth.spec.ts
@@ -7,7 +7,6 @@ describe('WebSessionAuth', () => {
   let mockRequest: Partial<Request>;
 
   const cookies = {
-    sess_guid: 'someCookie1',
     a95b4b6: 'someCookie2',
     d4a79ec: 'someCookie3',
     '159e76e': 'someCookie4',
@@ -28,13 +27,6 @@ describe('WebSessionAuth', () => {
   });
 
   describe('fromRequest', () => {
-    it('returns null if no sess_guid', () => {
-      delete mockRequest.cookies.sess_guid;
-      const wsAuth = WebSessionAuth.fromRequest(mockRequest as Request);
-
-      expect(wsAuth).toBeNull();
-    });
-
     it('returns null if no a95b4b6', () => {
       delete mockRequest.cookies.a95b4b6;
       const wsAuth = WebSessionAuth.fromRequest(mockRequest as Request);

--- a/src/auth/web-session/webSessionAuth.ts
+++ b/src/auth/web-session/webSessionAuth.ts
@@ -5,7 +5,6 @@ import { GraphQLClient } from 'graphql-request';
 
 // internal utility types
 type ExpectedCookies = {
-  sess_guid?: string;
   a95b4b6?: string;
   d4a79ec?: string;
   '159e76e'?: string;
@@ -30,10 +29,6 @@ export class WebSessionAuth implements WebAuth {
    */
   private lookupId: string;
   /**
-   * derived session identifier, this is not sensitive and is logged in sentry
-   */
-  private sessionGuid: string;
-  /**
    * direct session identifier, Do not expose this unless being used for auth.
    */
   private sessionIdentifier: string;
@@ -48,7 +43,6 @@ export class WebSessionAuth implements WebAuth {
     cookies: NonNullable<ExpectedCookies>,
     headers: NonNullable<ExpectedHeaders>
   ) {
-    this.sessionGuid = cookies.sess_guid;
     this.encodedUserIdentifier = cookies.a95b4b6;
     this.sessionIdentifier = cookies.d4a79ec;
     this.lookupId = cookies['159e76e'];
@@ -67,7 +61,6 @@ export class WebSessionAuth implements WebAuth {
     // ensure expected headers and cookies are present and non-empty
     if (
       !requestHeaders.cookie ||
-      !requestCookies.sess_guid ||
       !requestCookies.a95b4b6 ||
       !requestCookies.d4a79ec ||
       !requestCookies['159e76e']

--- a/src/auth/web-session/webSessionAuthHandler.spec.ts
+++ b/src/auth/web-session/webSessionAuthHandler.spec.ts
@@ -20,7 +20,6 @@ app.get('/authenticated', (req: express.Request, res: express.Response) => {
 
 describe('WebSessionAuthHandler', () => {
   const cookies = {
-    sess_guid: 'someCookie1',
     a95b4b6: 'someCookie2',
     d4a79ec: 'someCookie3',
     '159e76e': 'someCookie4',
@@ -41,10 +40,10 @@ describe('WebSessionAuthHandler', () => {
   });
 
   describe('unhappy path', () => {
-    it('returns 401 status error if no consumer_key is present', async () => {
-      // remove sess_guid
+    it('returns 401 status error if no a95b4b6 is present', async () => {
+      // remove a95b4b6
       const requestCookies = { ...cookies };
-      delete requestCookies.sess_guid;
+      delete requestCookies.a95b4b6;
 
       const res = await request(app)
         .get('/authenticated')


### PR DESCRIPTION
## Goal
Sorry for the book, trying to document lessons learned. Two fixes here:

1. Remove references to `sess_guid` cookie entirely from service.

This service relies on cookie based auth, and validates the presence of cookies before sending requests off to the GraphQL proxy. There are a couple reasons I made this decision:
- This service doesn't live on the same domain as the graphql proxy, so it can't really act as a dumb proxy without introducing synchronization issues between getpocket.com cookies and readitlater.com cookies.
- From my own personal experiences, older cookie based auth flows really only work well when evaluated in a browser window context.

`sess_guid` is also documented as a requirement for WebSession auth in all of the documentation I've read around it, and the php implementation of WebSession suggests it will throw an exception if it is not present. Between this, and the concerns above, validating cookies and giving an explicit error seemed like a better outcome than dealing with opaque errors upstream. However, it seems there is another middleware that will populate `sess_guid` and send a set-cookie header response that evaluates before the WebSession auth handler, so it is not actually a requirement or a necessary part of auth! This cookie also expires with `session` rather than based on time, so if it expires auth is blocked until a request is made to getpocket.com to reset it. I still cannot proxy this set-cookie response reliably, so I am just removing references to this cookie entirely. Some other mechanism will have to be used for session tracking if we need this in our metrics.

2. Support `consumer_key` via query params in addition to headers.

This is more speculative, and hasn't had a recorded reproduction, but I have heard a client report that `consumer_key` validation may have failed. I wanted to support client identifiers via headers to allow configuring a client rather than having to include it in every request. `consumer_key` is not actually valid as defined in RFCs (_ is not valid). Many services support it anyway. I suspect some weird edge case in a load balancer could be dropping it if it attempts to inspect headers. Just getting this in while we're touching adjacent things.

Rather than introducing even more confusion here by renaming the header to something valid (this is an option if you have a strong preference for it!), just supporting it via query params as in v3 APIs seemed less ambiguous

Both of these changes are backwards compatible with deployments in firefox nightly.

## I'd love feedback/perspectives on:
- Does this make sense? We can talk about it more if needed. No immediate changes in the client are required, and `consumer_key` can be moved to query parameters at any time.

## Implementation Decisions
- Everything is backwards compatible.

## Deployment steps
N/A

