### PR TITLE
fix(proxy-headers): transition header forwarding to block list

### DIFF
--- a/src/auth/web-session/webSessionAuth.ts
+++ b/src/auth/web-session/webSessionAuth.ts
@@ -2,6 +2,7 @@ import { Request } from 'express';
 
 import { WebAuth } from '../types';
 import { GraphQLClient } from 'graphql-request';
+import { doForwardHeader } from '../../lib/headerUtils';
 
 // internal utility types
 type ExpectedCookies = {
@@ -11,35 +12,6 @@ type ExpectedCookies = {
 };
 type ExpectedHeaders = {
   cookie?: string;
-};
-
-/**
- * The web repo closes the connection if headers are forwarded indiscriminately,
- * this set and the function below let through any explicitly allowed headers, and
- * any headers that begin with `x-` (application specific).
- *
- * As we move forward with observability improvements, ensure that any tracking
- * headers get added here, or are permitted in doForwardHeader.
- *
- * Hopefully we can move this to a block-list instead, but I need to know more to
- * get there.
- */
-const ALLOWED_HEADERS = new Set(['authorization', 'cookie']);
-
-/**
- * returns true if cookie is explicitly allowed or application specific
- * @param name
- * @returns boolean
- */
-const doForwardHeader = (name: string): boolean => {
-  const lowerName = name.toLocaleLowerCase();
-  if (ALLOWED_HEADERS.has(lowerName)) {
-    return true;
-  }
-  if (lowerName.startsWith('x-')) {
-    return true;
-  }
-  return false;
 };
 
 export class WebSessionAuth implements WebAuth {

--- a/src/graphql-proxy/lib/client.spec.ts
+++ b/src/graphql-proxy/lib/client.spec.ts
@@ -60,9 +60,8 @@ describe('GraphQL Client', () => {
         {}
       );
 
-      // for this case, it is the Map interface, so 4 separate set calls due to forEach
-      // the extra 2 are content-length and content-type, which are automatic
-      expect(mockResponse.set).toBeCalledTimes(4);
+      // each header is set individually, expect 2 calls
+      expect(mockResponse.set).toBeCalledTimes(2);
       expect(mockResponse.set).toBeCalledWith(
         'multiple',
         'all headers get forwarded'

--- a/src/graphql-proxy/lib/client.ts
+++ b/src/graphql-proxy/lib/client.ts
@@ -2,6 +2,7 @@ import { ClientError, GraphQLClient } from 'graphql-request';
 import express from 'express';
 import config from '../../config';
 import { consumer_key } from '../../auth/types';
+import { doForwardHeader } from '../../lib/headerUtils';
 
 /**
  * GraphQL Client doesn't export this type due to supporting arbitrary
@@ -84,13 +85,17 @@ export const forwardHeadersMiddleware =
         // When they are present they may be accessed like this. Guarding
         // with optional chaining to provide best effort header forwarding.
         graphResponse.response?.headers?.forEach((value, key) => {
-          expressResponse.set(key, value);
+          if (doForwardHeader(key)) {
+            expressResponse.set(key, value);
+          }
         })
       } else if (graphResponse?.headers?.forEach) {
         // cannot use instanceof operator on Response, just check for headers
         // being a map type to check for this case
         graphResponse.headers.forEach((value, key) => {
-          expressResponse.set(key, value);
+          if (doForwardHeader(key)) {
+            expressResponse.set(key, value);
+          }
         });
       } else {
         // I think all expected types are documented above, emit warning log

--- a/src/lib/headerUtils.ts
+++ b/src/lib/headerUtils.ts
@@ -1,0 +1,52 @@
+/**
+ * This service forwards headers to and from the web repo
+ * graph proxy. These utilities are common code, primarily
+ * concerned with blocking the forwarding of some headers.
+ */
+
+/**
+ * This is a central list for headers that either must be blocked
+ * (hop-by-hop), and headers that are problematic to upstream
+ * / downstream services.
+ *
+ * This may need to be separated into separate lists for request
+ * forwarding and response forwarding, but starting with just one
+ * list.
+ */
+const forwardHeaderBlockList = [
+  // https://www.rfc-editor.org/rfc/rfc2616#section-13.5.1
+  // hop-by-hop headers must not be forwarded in proxied requests
+  'Connection',
+  'Keep-Alive',
+  'Proxy-Authenticate',
+  'Proxy-Authorization',
+  'TE',
+  'Trailers',
+  'Transfer-Encoding',
+  'Upgrade',
+  // additionally, there are some programmatic headers
+  // we want to block.
+  'Content-Length',
+  'Content-Type',
+  'Content-Encoding',
+  'User-Agent',
+  'Host',
+  'Accept-Encoding',
+  'Connection',
+];
+
+// to set for constant lookup
+const forwardHeaderBlockSet = new Set(
+  // all to lowercase to avoid case sensitivity issues
+  forwardHeaderBlockList.map((h) => h.toLocaleLowerCase())
+);
+
+/**
+ * Provided a header name, returns a boolean indicating
+ * whether to forward the header on proxy requests or
+ * responses.
+ *
+ * @param headerName
+ */
+export const doForwardHeader = (headerName: string): boolean =>
+  !forwardHeaderBlockSet.has(headerName.toLowerCase());


### PR DESCRIPTION
## Goal
There are some issues with the current header forwarding. In particular, some of the content realated programmatic headers are not being set by express, and are being set upstream in the graph proxy. These content mis-matches are resulting in errors in firefox.

This fix transitions the service to blocking header forwarding based on a block-list, rather than permitting headers based on an allow-list. Hopefully this is more stable.

Additionally, I did some digging into proxy headers, and found the spec for hop-by-hop headers, and added all of these to the block-list.

These changes have already been validated with @ScottDowne. We were debugging together, and requests were proxied by my local instance.

## I'd love feedback/perspectives on:
- Can you think of any other headers that might be problematic?

## Implementation Decisions
- Went with a block-list.  I think this should result in less pain on average than the allow-list.

## Deployment steps
N/A

## References
