### PR TITLE
chore(upgrade-ci-orb): set pocket/circleci-orbs@2.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  pocket: pocket/circleci-orbs@1.2.8
+  pocket: pocket/circleci-orbs@2.1.1
   backstage-entity-validator: roadiehq/backstage-entity-validator@0.4.2
 
 # Workflow shortcuts


### PR DESCRIPTION
I'm not sure what broke from ~1 to ~2, will double back if something breaks.

## Goal
Upgrade to latest circleci orb

## I'd love feedback/perspectives on:
- Can renovate do this?

## Implementation Decisions
- N/A

## Deployment steps
- monitor for breaks

## References
Onsite devops day
