### PR TITLE
deploymen bugfix - invalid waf rule action definition

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -300,7 +300,7 @@ class Stack extends TerraformStack {
     const mozillaOpsSourceRule = <Wafv2WebAclRule>{
       name: 'MozillaOpsSource',
       priority: 0,
-      action: [{ count: [{}] }],
+      action: { count: {} },
       statement: [
         {
           byteMatchStatement: [


### PR DESCRIPTION
See #42 for more context.
https://github.com/Pocket/firefox-api-proxy/pull/42

This included some rules that were originally defined in dotcom-gateway, and it seems the action syntax used there has been deprecated.

I believe this should sort things out.

## Goal
Fix deployment

## I'd love feedback/perspectives on:
N/A 

## Implementation Decisions
N/A

## Deployment steps
N/A

## References
N/A