### PR TITLE
more deployment bugfixes - remove all cdktf array syntax

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -301,31 +301,23 @@ class Stack extends TerraformStack {
       name: 'MozillaOpsSource',
       priority: 0,
       action: { count: {} },
-      statement: [
-        {
-          byteMatchStatement: [
+      statement: {
+        byteMatchStatement: {
+          searchString: 'mozilla',
+          fieldToMatch: {
+            singleHeader: {
+              name: 'x-source',
+            },
+          },
+          textTransformation: [
             {
-              searchString: 'mozilla',
-              fieldToMatch: [
-                {
-                  singleHeader: [
-                    {
-                      name: 'x-source',
-                    },
-                  ],
-                },
-              ],
-              textTransformation: [
-                {
-                  priority: 0,
-                  type: 'LOWERCASE',
-                },
-              ],
-              positionalConstraint: 'EXACTLY',
+              priority: 0,
+              type: 'LOWERCASE',
             },
           ],
+          positionalConstraint: 'EXACTLY',
         },
-      ],
+      },
       visibilityConfig: {
         cloudwatchMetricsEnabled: true,
         metricName: 'MozillaOpsSource',


### PR DESCRIPTION
See #42, #43 for more details.

Remove all array syntax for all of mozillaOpsSourceRule waf rule.

I'm not sure why type checking is failing so badly here, but I think it might be related to not having cdktf declared as a dependency, and just implicitly inheriting it from terraform-modules.

Removed every array other than textTransformation (it contains priorities, which suggests it needs to be an array).

## Goal
Hopefully deploy

## I'd love feedback/perspectives on:
- See any other problems here?

## Implementation Decisions
N/A

## Deployment steps
N/A

## References
N/A
