### PR TITLE
fix(cacheControl): [INFRA-1290] Add the `Cache-control` header to the forward headers blocklist

### DIFF
--- a/src/api/desktop/recommendations/recommendations.spec.ts
+++ b/src/api/desktop/recommendations/recommendations.spec.ts
@@ -61,6 +61,7 @@ describe('recommendations API server', () => {
       body: {
         data: mockResponse,
       },
+      headers: { ['Cache-control']: 'private,max-age=900' }, // This should be overwritten by the individual endpoint below
     });
 
     const params = new URLSearchParams();

--- a/src/lib/headerUtils.ts
+++ b/src/lib/headerUtils.ts
@@ -33,6 +33,7 @@ const forwardHeaderBlockList = [
   'Host',
   'Accept-Encoding',
   'Connection',
+  'Cache-control',
 ];
 
 // to set for constant lookup


### PR DESCRIPTION
## Goal
Add the Cache-control header to the forward headers blocklist so that `../v1/recommendations` route's cache control overwrite is honoured.
 
## References

JIRA ticket:
* [INFRA-1290](https://getpocket.atlassian.net/browse/INFRA-1290)

[INFRA-1290]: https://getpocket.atlassian.net/browse/INFRA-1290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ