### PR TITLE
feat(Recommendations): Rename operation to NewTabRecommendations

### DIFF
--- a/src/graphql-proxy/recommendations/Recommendations.graphql
+++ b/src/graphql-proxy/recommendations/Recommendations.graphql
@@ -1,4 +1,4 @@
-query Recommendations($locale: String!, $region: String, $count: Int) {
+query NewTabRecommendations($locale: String!, $region: String, $count: Int) {
   newTabSlate(locale: $locale, region: $region) {
     recommendations(count: $count) {
       tileId


### PR DESCRIPTION
## Goal
Give a more distinct, meaningful name to the newTabSlate operation, such that it can be distinguished from other recommendation operations in Apollo Studio and other tooling.

## I'd love feedback/perspectives on:
- Should the graphql filename be renamed as well?
- Would folks prefer a different name?

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/DIS-781