### PR TITLE
feat(recommendations): [DIS-802] Add static utm_source to url

### DIFF
--- a/src/api/desktop/recommendations/response.spec.ts
+++ b/src/api/desktop/recommendations/response.spec.ts
@@ -2,7 +2,7 @@ import Ajv, { DefinedError } from 'ajv';
 
 import OpenApiSpec from '../../OpenAPISpec';
 import Recommendations from '../../../graphql-proxy/recommendations/recommendations';
-import { responseTransformer } from './response';
+import { appendUtmSource, responseTransformer } from './response';
 import { WebAuth } from '../../../auth/types';
 
 jest.mock('../../../graphql-proxy/recommendations/recommendations');
@@ -47,9 +47,32 @@ describe('response', () => {
       if (valid) {
         // any additional expectations can be defined here
         expect(res.data.length).toEqual(30);
+        expect(res.data[0].url.endsWith('utm_source=pocket-newtab-bff'));
       } else {
         throw validate.errors;
       }
+    });
+  });
+
+  describe('appendUtmSource', () => {
+    it('should add a utm_source query parameter when input URL does not have any query parameters', () => {
+      const url = 'https://example.com';
+      const expected = 'https://example.com/?utm_source=pocket-newtab-bff';
+      expect(appendUtmSource(url)).toBe(expected);
+    });
+
+    it('should add a utm_source query parameter when the input URL already has a query parameter', () => {
+      const url = 'https://example.com?foo=bar';
+      const expected =
+        'https://example.com/?foo=bar&utm_source=pocket-newtab-bff';
+      expect(appendUtmSource(url)).toBe(expected);
+    });
+
+    it('should add utm_source query parameter when the input URL ends with a fragment', () => {
+      const url = 'https://example.com#my-fragment';
+      const expected =
+        'https://example.com/?utm_source=pocket-newtab-bff#my-fragment';
+      expect(appendUtmSource(url)).toBe(expected);
     });
   });
 });

--- a/src/api/desktop/recommendations/response.spec.ts
+++ b/src/api/desktop/recommendations/response.spec.ts
@@ -74,5 +74,11 @@ describe('response', () => {
         'https://example.com/?utm_source=pocket-newtab-bff#my-fragment';
       expect(appendUtmSource(url)).toBe(expected);
     });
+
+    it('should override utm_source query parameter if the url already contains utm_source', () => {
+      const url = 'https://example.com/?utm_source=fgfeed';
+      const expected = 'https://example.com/?utm_source=pocket-newtab-bff';
+      expect(appendUtmSource(url)).toBe(expected);
+    });
   });
 });

--- a/src/api/desktop/recommendations/response.ts
+++ b/src/api/desktop/recommendations/response.ts
@@ -12,13 +12,26 @@ export type RecommendationsResponse =
   paths['/desktop/v1/recommendations']['get']['responses']['200']['content']['application/json'];
 type Recommendation = components['schemas']['Recommendation'];
 
+export const appendUtmSource = (url: string): string => {
+  const urlObject = new URL(url);
+  const searchParams = new URLSearchParams(urlObject.search);
+
+  // Set a static utm_source to attribute traffic to the new NewTab markets.
+  // TODO: [DIS-803] Make utm_source unique per ScheduledSurface,
+  //  before migrating Firefox Release en-US to this API.
+  searchParams.set('utm_source', 'pocket-newtab-bff');
+  urlObject.search = searchParams.toString();
+
+  return urlObject.toString();
+};
+
 export const mapRecommendation = (
   recommendation: GraphRecommendation
 ): Recommendation => {
   return {
     __typename: 'Recommendation',
     tileId: recommendation.tileId,
-    url: recommendation.corpusItem.url,
+    url: appendUtmSource(recommendation.corpusItem.url),
     title: recommendation.corpusItem.title,
     excerpt: recommendation.corpusItem.excerpt,
     publisher: recommendation.corpusItem.publisher,


### PR DESCRIPTION
## Goal
Add a `utm_source` query parameter to the URL to:
1. Allow publishers to attribute traffic coming from NewTab.
2. Attribute Pocket sign-ups to NewTab.


## I'd love feedback/perspectives on:
- Whether this is a reasonable short-term solution.

## Implementation Decisions
- Kirill requested that the `utm_source` value is distinct from existing feeds, but it may be the same value for ES, FR, IT. Before we migrate existing markets over to this API, the `utm_source` value should be unique per ScheduledSurface. [DIS-803](https://getpocket.atlassian.net/browse/DIS-803?atlOrigin=eyJpIjoiOTU0ZmUyYWQ1ZDQwNDgzNDlhNzA4NGEwZDAwYzRkZjQiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Deployment steps
- [ ] **FOR POCKET DEVELOPERS ONLY** - Post in [\#changelog](https://pocket.slack.com/archives/C0Q4UFMDZ):
> NewTab recommendation urls for France, Italy, Spain now have a `utm_source` parameter that's set to pocket-newtab-bff, such that publishers can attribute the traffic we send their way, and we can track sign-ups. [#51](https://github.com/Pocket/firefox-api-proxy/pull/51)

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/DIS-802?atlOrigin=eyJpIjoiN2QwZjIwZGE3MTkxNDAwNmE3OGQ2NzkzYTEzMTVjYWQiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

Slack thread:
* https://pocket.slack.com/archives/C04LKH4J1M0/p1686088250963949


[DIS-803]: https://getpocket.atlassian.net/browse/DIS-803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ