### PR TITLE
feat(recommendations): [DIS-648] Add locales & regions

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -227,7 +227,7 @@ paths:
               es, es-ES,
               it, it-IT,
               en, en-CA, en-GB, en-US,
-              de, de-DE, de-AT, de-CH
+              de, de-DE, de-AT, de-CH,
             ]
         - name: region
           in: query

--- a/openapi.yml
+++ b/openapi.yml
@@ -221,14 +221,14 @@ paths:
             enum: [
               # relevant docs: https://docs.google.com/document/d/1omclr-eETJ7zAWTMI7mvvsc3_-ns2Iiho4jPEfrmZfo
               # listing locales that should still be served through the v3 APIs,
-              # these are intentionally disabled for now.
-              # en-CA, en-GB, en-US,
-              # de, de-AT, de-CH,
 
-              # new markets will be served through this API:
+              # fr, es, it will be served through this API in Firefox 114,
+              # and we plan to migrate all NewTab markets in Firefox 116:
               fr, fr-FR,
               es, es-ES,
               it, it-IT,
+              en, en-CA, en-GB, en-US,
+              de, de-DE, de-AT, de-CH
             ]
         - name: region
           in: query
@@ -319,7 +319,7 @@ paths:
                 properties:
                   data:
                     type: array
-                    items: 
+                    items:
                       oneOf:
                         - $ref: "#/components/schemas/Save"
                         - $ref: "#/components/schemas/PendingSave"

--- a/openapi.yml
+++ b/openapi.yml
@@ -237,9 +237,6 @@ paths:
             type: string
             enum: [
               # relevant docs: https://docs.google.com/document/d/1omclr-eETJ7zAWTMI7mvvsc3_-ns2Iiho4jPEfrmZfo
-
-              # FR, ES, IT are served through this API in Firefox 114,
-              # and we plan to migrate all NewTab markets in Firefox 116:
               US, CA, DE, GB, IE, FR, ES, IT, IN, CH, AT, BE,
             ]
       responses:

--- a/openapi.yml
+++ b/openapi.yml
@@ -220,9 +220,8 @@ paths:
             type: string
             enum: [
               # relevant docs: https://docs.google.com/document/d/1omclr-eETJ7zAWTMI7mvvsc3_-ns2Iiho4jPEfrmZfo
-              # listing locales that should still be served through the v3 APIs,
 
-              # fr, es, it will be served through this API in Firefox 114,
+              # fr, es, it are served through this API in Firefox 114,
               # and we plan to migrate all NewTab markets in Firefox 116:
               fr, fr-FR,
               es, es-ES,
@@ -238,12 +237,10 @@ paths:
             type: string
             enum: [
               # relevant docs: https://docs.google.com/document/d/1omclr-eETJ7zAWTMI7mvvsc3_-ns2Iiho4jPEfrmZfo
-              # listing regions that should still be served through the v3 APIs,
-              # these are intentionally disabled for now.
-              # US, CA, DE, GB, IN, CH, AT, BE, IE
 
-              # new markets will be served through this API:
-              FR, ES, IT,
+              # FR, ES, IT are served through this API in Firefox 114,
+              # and we plan to migrate all NewTab markets in Firefox 116:
+              US, CA, DE, GB, IE, FR, ES, IT, IN, CH, AT, BE,
             ]
       responses:
         '200':

--- a/src/api/desktop/recommendations/inputs.spec.ts
+++ b/src/api/desktop/recommendations/inputs.spec.ts
@@ -25,7 +25,8 @@ const randomLocale = () =>
     'de-CH',
   ]);
 
-const randomRegion = () => faker.helpers.arrayElement(['FR', 'ES', 'IT']);
+const randomRegion = () =>
+  faker.helpers.arrayElement(['FR', 'ES', 'IT', 'DE', 'US', 'CA', 'IN']);
 
 describe('input.ts recommendations query parameters', () => {
   describe('setDefaultsAndCoerceTypes', () => {
@@ -141,7 +142,8 @@ describe('input.ts recommendations query parameters', () => {
               status: '400',
               title: 'Bad Request',
               detail:
-                'Region must be provided. Valid regions include ["FR","ES","IT"]',
+                'Region must be provided. Valid regions include [' +
+                '"US","CA","DE","GB","IE","FR","ES","IT","IN","CH","AT","BE"]',
               source: {
                 parameters: 'region',
               },
@@ -177,7 +179,8 @@ describe('input.ts recommendations query parameters', () => {
               status: '400',
               title: 'Bad Request',
               detail:
-                'Region must be provided. Valid regions include ["FR","ES","IT"]',
+                'Region must be provided. Valid regions include [' +
+                '"US","CA","DE","GB","IE","FR","ES","IT","IN","CH","AT","BE"]',
               source: {
                 parameters: 'region',
               },

--- a/src/api/desktop/recommendations/inputs.spec.ts
+++ b/src/api/desktop/recommendations/inputs.spec.ts
@@ -12,7 +12,18 @@ import {
 import { APIError, APIErrorResponse, BFFFxError } from '../../../bfffxError';
 
 const randomLocale = () =>
-  faker.helpers.arrayElement(['fr', 'fr-FR', 'es', 'es-ES', 'it', 'it-IT']);
+  faker.helpers.arrayElement([
+    'fr',
+    'fr-FR',
+    'es',
+    'es-ES',
+    'it',
+    'it-IT',
+    'en',
+    'en-CA',
+    'de',
+    'de-CH',
+  ]);
 
 const randomRegion = () => faker.helpers.arrayElement(['FR', 'ES', 'IT']);
 
@@ -119,7 +130,9 @@ describe('input.ts recommendations query parameters', () => {
               status: '400',
               title: 'Bad Request',
               detail:
-                'Locale must be provided. Valid locales include: ["fr","fr-FR","es","es-ES","it","it-IT"]',
+                'Locale must be provided. Valid locales include: [' +
+                '"fr","fr-FR","es","es-ES","it","it-IT","en","en-CA",' +
+                '"en-GB","en-US","de","de-DE","de-AT","de-CH"]',
               source: {
                 parameters: 'locale',
               },
@@ -153,7 +166,9 @@ describe('input.ts recommendations query parameters', () => {
               status: '400',
               title: 'Bad Request',
               detail:
-                'Locale must be provided. Valid locales include: ["fr","fr-FR","es","es-ES","it","it-IT"]',
+                'Locale must be provided. Valid locales include: [' +
+                '"fr","fr-FR","es","es-ES","it","it-IT","en","en-CA",' +
+                '"en-GB","en-US","de","de-DE","de-AT","de-CH"]',
               source: {
                 parameters: 'locale',
               },

--- a/src/api/desktop/recommendations/inputs.ts
+++ b/src/api/desktop/recommendations/inputs.ts
@@ -79,7 +79,20 @@ const isValidLocale: ValidatorFunction = (locale?: string) =>
     : null;
 
 // all valid regions
-const validRegions = ['FR', 'ES', 'IT'];
+const validRegions = [
+  'US',
+  'CA',
+  'DE',
+  'GB',
+  'IE',
+  'FR',
+  'ES',
+  'IT',
+  'IN',
+  'CH',
+  'AT',
+  'BE',
+];
 // copy to set for fast lookup, all lowercase
 const validRegionsSet = new Set(
   validRegions.map((region) => region.toLowerCase())

--- a/src/api/desktop/recommendations/inputs.ts
+++ b/src/api/desktop/recommendations/inputs.ts
@@ -37,7 +37,22 @@ type ValidatorFunction = (value: any) => {
 };
 
 // all valid locales
-const validLocales = ['fr', 'fr-FR', 'es', 'es-ES', 'it', 'it-IT'];
+const validLocales = [
+  'fr',
+  'fr-FR',
+  'es',
+  'es-ES',
+  'it',
+  'it-IT',
+  'en',
+  'en-CA',
+  'en-GB',
+  'en-US',
+  'de',
+  'de-DE',
+  'de-AT',
+  'de-CH',
+];
 // copy to set for fast lookup, all lowercase
 const validLocalesSet = new Set(
   validLocales.map((locale) => locale.toLowerCase())


### PR DESCRIPTION
## Goal
Unblock Firefox 116 Nightly from switching to this API for NewTab recommendations in existing markets.

## Implementation Decisions
- I'm a bit out of my comfort zone in this repo, so I did not make any effort to avoid duplicating locales & regions. My main hope was that making a start with this change would be helpful.

## Deployment steps
PRs that need to be deployed before this PR:

- [x] [#393](https://github.com/Pocket/dbt-snowflake/pull/393) Snowflake tests do not fail for Firefox locales.
- [x] [#201](https://github.com/Pocket/spec/pull/201) Snowplow schema accepts Firefox locales.
- [x] [#1046](https://github.com/Pocket/recommendation-api/pull/1046) Recommendation-api maps locale & region to the right market.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/DIS-648

Documentation:
* [NewTab locales/region config](https://docs.google.com/document/d/1omclr-eETJ7zAWTMI7mvvsc3_-ns2Iiho4jPEfrmZfo/edit)


[DIS-648]: https://getpocket.atlassian.net/browse/DIS-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ