### PR TITLE
feat(GlobalRecs): Add /v3/firefox/global-recs API

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -353,7 +353,7 @@ paths:
         - in: query
           name: locale_lang
           description: Firefox locale
-          required: false
+          required: true
           schema:
             type: string
             default: en-US

--- a/openapi.yml
+++ b/openapi.yml
@@ -153,6 +153,62 @@ components:
           type: string
           description: The primary image for a Recommendation.
 
+    LegacyFeedItem:
+      type: object
+      required:
+        - id
+        - title
+        - url
+        - excerpt
+        - domain
+        - image_src
+        - raw_image_src
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        url:
+          type: string
+        excerpt:
+          type: string
+        domain:
+          type: string
+        image_src:
+          type: string
+        raw_image_src:
+          type: string
+
+    LegacySettings:
+      type: object
+      properties:
+        spocsPerNewTabs:
+          type: number
+        domainAffinityParameterSets:
+          type: object
+        timeSegments:
+          type: array
+          items:
+            type: object
+            required:
+              - id
+              - startTime
+              - endTime
+              - weightPosition
+            properties:
+              id:
+                type: string
+              startTime:
+                type: integer
+              endTime:
+                type: integer
+              weightPosition:
+                type: number
+        recsExpireTime:
+          type: integer
+        version:
+          type: string
+
   # securitySchemes roughly map to authentication middleware
   securitySchemes:
     # The following schemes prefixed with "WS" all constitute a `WebSession` auth.
@@ -199,8 +255,8 @@ paths:
       operationId: getRecommendations
       # Intentionally blank security. No auth required.
       security:
-        - WSConsumerKeyAuth: []
-        - WSConsumerKeyAuthAlias: []
+        - WSConsumerKeyAuth: [ ]
+        - WSConsumerKeyAuthAlias: [ ]
       parameters:
         - name: count
           in: query
@@ -274,6 +330,93 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /v3/firefox/global-recs:
+    get:
+      deprecated: true
+      summary: Used by older versions of Firefox to get a list of Recommendations for a Locale and Region. This operation is performed anonymously and requires no auth.
+      description: Supports Fx desktop version 115 and below.
+      operationId: getGlobalRecs
+      # Intentionally blank security. No auth required.
+      security:
+        - WSConsumerKeyAuth: [ ]
+        - WSConsumerKeyAuthAlias: [ ]
+      parameters:
+        - in: query
+          name: version
+          description: API version
+          required: true
+          schema:
+            type: integer
+            minimum: 3
+            maximum: 3
+            default: 3
+        - in: query
+          name: locale_lang
+          description: Firefox locale
+          required: false
+          schema:
+            type: string
+            default: en-US
+        - in: query
+          name: region
+          description: Firefox region
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: count
+          description: Maximum number of items to return
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 20
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - status
+                  - spocs
+                  - settings
+                  - recommendations
+                properties:
+                  status:
+                    type: integer
+                    enum:
+                      - 1
+                  spocs:
+                    type: array
+                  settings:
+                    $ref: "#/components/schemas/LegacySettings"
+                  recommendations:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/LegacyFeedItem"
+        '400':
+          description: Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        '500':
+          description: This proxy service encountered an unexpected error.
+        '502':
+          description: Services downstream from this proxy encountered an unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        '504':
+          description: Requests to downstream services timed out.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /desktop/v1/recent-saves:
     get:
       summary: Gets a list of the most recent saves for a specific user.
@@ -281,14 +424,14 @@ paths:
       operationId: getRecentSaves
       security:
         # require all WS (WebSession) security schemes together
-        - WSUserAuth: []
-          WSSessionAuth: []
-          WSLookupAuth: []
-          WSConsumerKeyAuth: []
-        - WSUserAuth: []
-          WSSessionAuth: []
-          WSLookupAuth: []
-          WSConsumerKeyAuthAlias: []
+        - WSUserAuth: [ ]
+          WSSessionAuth: [ ]
+          WSLookupAuth: [ ]
+          WSConsumerKeyAuth: [ ]
+        - WSUserAuth: [ ]
+          WSSessionAuth: [ ]
+          WSLookupAuth: [ ]
+          WSConsumerKeyAuthAlias: [ ]
       parameters:
         - name: count
           in: query

--- a/src/api/desktop/recent-saves/response.spec.ts
+++ b/src/api/desktop/recent-saves/response.spec.ts
@@ -24,7 +24,7 @@ describe('response', () => {
   // quick test to show ajv behavior, may not be familiar
   it('ajv returns errors when bad objects', () => {
     const valid = validate({});
-    expect(!valid).toBeTruthy();
+    expect(valid).toBeFalsy();
     // uncomment if you want info about how errors look
     // throw validate.errors
     expect((validate.errors as DefinedError[]).length).toBeGreaterThan(0);

--- a/src/api/desktop/recommendations/response.spec.ts
+++ b/src/api/desktop/recommendations/response.spec.ts
@@ -18,7 +18,7 @@ const validate = ajv.compile(schema);
 describe('response', () => {
   it('ajv returns errors when bad objects', () => {
     const valid = validate({});
-    expect(!valid).toBeTruthy();
+    expect(valid).toBeFalsy();
     // uncomment if you want info about how errors look
     // throw validate.errors
     expect((validate.errors as DefinedError[]).length).toBeGreaterThan(0);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,6 +3,7 @@ const router = express.Router();
 
 import config from '../config';
 import Desktop from './desktop';
+import V3 from './v3';
 import CacheControlHandler from './lib/cacheControlHandler';
 import WebSessionAuthHandler from '../auth/web-session/webSessionAuthHandler';
 
@@ -16,6 +17,18 @@ router.use(
   CacheControlHandler('private, max-age=1800', config),
   // register Desktop sub-router
   Desktop
+);
+
+// register all /desktop routes
+router.use(
+  '/v3',
+  // include auth if available
+  WebSessionAuthHandler,
+  // set Cache-control headers on all routes
+  // this can be overwritten on downstream routes with another handler
+  CacheControlHandler('private, max-age=1800', config),
+  // register legacy v3 sub-router
+  V3
 );
 
 export default router;

--- a/src/api/v3/index.ts
+++ b/src/api/v3/index.ts
@@ -19,14 +19,12 @@ router.get(
   CacheControlHandler('public, max-age=1800', config),
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      //console.log(req)
       const variables = handleQueryParameters(req.query);
 
       if (variables instanceof BFFFxError) {
         return next(variables);
       }
 
-      console.log(variables);
       const graphRes = await Recommendations({
         auth: req.auth,
         consumer_key: req.consumer_key,
@@ -36,7 +34,6 @@ router.get(
 
       res.json(responseTransformer(graphRes) as GlobalRecsResponse);
     } catch (error) {
-      console.log(error);
       const responseError = GraphQLErrorHandler(error);
       return next(responseError);
     }

--- a/src/api/v3/index.ts
+++ b/src/api/v3/index.ts
@@ -1,0 +1,46 @@
+import express, { NextFunction, Request, Response } from 'express';
+import config from '../../config';
+import CacheControlHandler from '../lib/cacheControlHandler';
+import ConsumerKeyHandler from '../../auth/consumerKeyHandler';
+import { GraphQLErrorHandler } from '../error/graphQLErrorHandler';
+import { handleQueryParameters } from './inputs';
+import { BFFFxError } from '../../bfffxError';
+import Recommendations from '../../graphql-proxy/recommendations/recommendations';
+import { forwardHeadersMiddleware } from '../../graphql-proxy/lib/client';
+import { RecommendationsQueryVariables } from '../../generated/graphql/types';
+import { GlobalRecsResponse, responseTransformer } from './response';
+
+const router = express.Router();
+
+router.get(
+  '/firefox/global-recs',
+  // request must include a consumer
+  ConsumerKeyHandler,
+  CacheControlHandler('public, max-age=1800', config),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      //console.log(req)
+      const variables = handleQueryParameters(req.query);
+
+      if (variables instanceof BFFFxError) {
+        return next(variables);
+      }
+
+      console.log(variables);
+      const graphRes = await Recommendations({
+        auth: req.auth,
+        consumer_key: req.consumer_key,
+        forwardHeadersMiddleware: forwardHeadersMiddleware(res),
+        variables: variables as RecommendationsQueryVariables,
+      });
+
+      res.json(responseTransformer(graphRes) as GlobalRecsResponse);
+    } catch (error) {
+      console.log(error);
+      const responseError = GraphQLErrorHandler(error);
+      return next(responseError);
+    }
+  }
+);
+
+export default router;

--- a/src/api/v3/inputs.spec.ts
+++ b/src/api/v3/inputs.spec.ts
@@ -1,0 +1,75 @@
+import { faker } from '@faker-js/faker';
+import assert from 'assert';
+
+import { RecommendationsQueryVariables } from '../../generated/graphql/types';
+import {
+  GlobalRecsQueryParameterStrings,
+  handleQueryParameters,
+  setDefaultsAndCoerceTypes,
+} from './inputs';
+
+import { APIError, APIErrorResponse, BFFFxError } from '../../bfffxError';
+
+describe('input.ts recommendations query parameters', () => {
+  describe('setDefaultsAndCoerceTypes', () => {
+    it('converts count to an integer and passes through others', () => {
+      const res = setDefaultsAndCoerceTypes({
+        count: '3',
+        locale_lang: 'preValidatedLocale',
+        region: 'preValidatedRegion',
+      });
+      expect(res).toMatchObject({
+        count: 3,
+        locale: 'preValidatedLocale',
+        region: 'preValidatedRegion',
+      });
+    });
+
+    it('sets count to 20 if no default is provided, values without defaults are undefined', () => {
+      const res = setDefaultsAndCoerceTypes({});
+      // validation should return an error in this case, validating defaults though
+      expect(res).toMatchObject({
+        count: 20,
+      });
+    });
+  });
+
+  describe('handleQueryParameters', () => {
+    it('returns errors if invalid query parameters', () => {
+      const params: GlobalRecsQueryParameterStrings = {
+        count: '-1',
+      };
+
+      const error = handleQueryParameters(params);
+      assert(error instanceof BFFFxError);
+      const errors = JSON.parse(error.stringResponse);
+      expect(errors).toEqual(
+        expect.objectContaining<APIErrorResponse>({
+          errors: expect.arrayContaining<Array<APIError>>([
+            expect.objectContaining<APIError>({
+              status: '400',
+              title: 'Bad Request',
+            }),
+          ]),
+        })
+      );
+    });
+
+    it('returns GraphQL query variables on success', () => {
+      const params: GlobalRecsQueryParameterStrings = {
+        count: faker.datatype.number({ min: 1, max: 30 }).toString(),
+        locale_lang: 'fr',
+        region: 'FR',
+      };
+
+      const variables = handleQueryParameters(params);
+      expect(variables).toStrictEqual(
+        expect.objectContaining<RecommendationsQueryVariables>({
+          count: parseInt(params.count, 10),
+          locale: params.locale_lang,
+          region: params.region,
+        })
+      );
+    });
+  });
+});

--- a/src/api/v3/inputs.ts
+++ b/src/api/v3/inputs.ts
@@ -1,0 +1,74 @@
+/**
+ * Input validators and transformers live here.
+ *
+ * Query validation is the one piece of this server that is not
+ * paired with the OpenAPI specification. Any changes to this file
+ * **MUST** have corresponding changes to the OpenAPI spec and vice
+ * versa.
+ */
+
+import { paths } from '../../generated/openapi/types';
+import { ToStringParams } from '../../types';
+import { RecommendationsQueryVariables } from '../../generated/graphql/types';
+import { BFFFxError, BFFFxErrorInstanceType } from '../../bfffxError';
+import { validate } from '../desktop/recommendations/inputs';
+
+export type GlobalRecsQueryParameters =
+  paths['/v3/firefox/global-recs']['get']['parameters']['query'];
+
+export type GlobalRecsQueryParameterStrings = Partial<
+  ToStringParams<GlobalRecsQueryParameters>
+>;
+
+/**
+ * Locale and region are required, however they do not have defaults,
+ * and we do not know if they are present until `validate` is executed.
+ * This type captures that uncertainty.
+ */
+type PreValidatedQueryParameters = {
+  count: number;
+  locale?: string;
+  region?: string;
+};
+
+/**
+ * Returns the set of query parameters with defaults filled in.
+ *
+ * Variables without defaults may not be present. None of these
+ * values have been validated yet.
+ *
+ * @param stringParams - express.req.query
+ */
+export const setDefaultsAndCoerceTypes = (
+  stringParams: GlobalRecsQueryParameterStrings
+): PreValidatedQueryParameters => {
+  return {
+    count: parseInt(stringParams.count ?? '20', 10),
+    region: stringParams.region,
+    locale: stringParams.locale_lang,
+  };
+};
+
+/**
+ * Use this in the route handler.
+ *
+ * Parses query parameter strings as provided by express.req.query,
+ * sets defaults, validates them, and transforms them into
+ * RecommendationsQueryVariables for the GraphQL client.
+ *
+ * This returns a discriminated union that includes errors. Be sure
+ * to check for them and return them to the client if present.
+ * @param query
+ */
+export const handleQueryParameters = (
+  query: GlobalRecsQueryParameterStrings
+): RecommendationsQueryVariables | BFFFxErrorInstanceType => {
+  const coerced = setDefaultsAndCoerceTypes(query);
+  const maybeValid = validate(coerced);
+
+  if (maybeValid instanceof BFFFxError) {
+    return maybeValid;
+  }
+
+  return maybeValid as RecommendationsQueryVariables;
+};

--- a/src/api/v3/recommendations.spec.ts
+++ b/src/api/v3/recommendations.spec.ts
@@ -1,0 +1,78 @@
+import request from 'supertest';
+import fetchMock from 'fetch-mock-jest';
+
+import RecommendationsMock from '../../graphql-proxy/recommendations/__mocks__/recommendations';
+
+import config from '../../config';
+import { buildBFFFxServer } from '../../bfffxServer';
+import { WebAuth } from '../../auth/types';
+
+import { components } from '../../generated/openapi/types';
+type LegacyFeedItem = components['schemas']['LegacyFeedItem'];
+
+/**
+ * This covers some happy path testing for complete server
+ * middleware composition. Unit tests still catch the finer
+ * details, this just ensures middleware is all working together.
+ *
+ * Fetch is mocked throughout this. Auth is the primary thing that
+ * is not being exercised, as the responses are mocked.
+ */
+
+const { app } = buildBFFFxServer();
+
+const CONSUMER_KEY = 'fakeConsumerKey';
+const buildGraphUrl = () =>
+  `${config.app.graphGatewayUrl}?consumer_key=${CONSUMER_KEY}&enable_cors=1`;
+
+describe('v3 legacy recommendations API server', () => {
+  beforeEach(() => {
+    // each test mocks its own responses in the test scope
+    fetchMock.mockReset();
+  });
+
+  it('transforms graphql responses to server responses', async () => {
+    const mockResponse = await RecommendationsMock({
+      // auth components and middlewares are unimportant to mocks,
+      // just mock them
+      auth: { junk: 'junk' } as unknown as WebAuth,
+      consumer_key: 'junkConsumerKey',
+      forwardHeadersMiddleware: () => null,
+      // provide real variables
+      variables: { count: 1, locale: 'it', region: 'IT' },
+    });
+
+    fetchMock.mock(buildGraphUrl(), {
+      status: 200,
+      body: {
+        data: mockResponse,
+      },
+      headers: { ['Cache-control']: 'private,max-age=900' }, // This should be overwritten by the individual endpoint below
+    });
+
+    const params = new URLSearchParams();
+    params.append('consumer_key', CONSUMER_KEY);
+    params.append('version', '3');
+    params.append('count', '1');
+    params.append('locale_lang', 'it');
+    params.append('region', 'IT');
+
+    const res = await request(app)
+      .get(`/v3/firefox/global-recs?${params.toString()}`)
+      .send()
+      .expect('Cache-control', 'public, max-age=1800'); // assert the Cache-control header is overwritten by the global-recs route
+
+    expect(res.status).toEqual(200);
+
+    // response ins json
+    const parsedRes = JSON.parse(res.text);
+    expect(parsedRes.recommendations?.length).toEqual(1);
+    const recommendation: LegacyFeedItem = parsedRes.recommendations[0];
+
+    // not checking exhaustively, just some general mapping
+    // response.spec.ts is responsible for keeping these in sync.
+    expect(recommendation.id).toEqual(
+      mockResponse.newTabSlate.recommendations[0].tileId
+    );
+  });
+});

--- a/src/api/v3/response.spec.ts
+++ b/src/api/v3/response.spec.ts
@@ -18,7 +18,7 @@ const validate = ajv.compile(schema);
 describe('response', () => {
   it('ajv returns errors when bad objects', () => {
     const valid = validate({});
-    expect(!valid).toBeTruthy();
+    expect(valid).toBeFalsy();
     // uncomment if you want info about how errors look
     // throw validate.errors
     expect((validate.errors as DefinedError[]).length).toBeGreaterThan(0);

--- a/src/api/v3/response.spec.ts
+++ b/src/api/v3/response.spec.ts
@@ -1,0 +1,58 @@
+import Ajv, { DefinedError } from 'ajv';
+
+import OpenApiSpec from '../OpenAPISpec';
+import Recommendations from '../../graphql-proxy/recommendations/recommendations';
+import { responseTransformer } from './response';
+import { WebAuth } from '../../auth/types';
+
+jest.mock('../../graphql-proxy/recommendations/recommendations');
+
+// initialize ajv for validation
+const ajv = new Ajv();
+const schema =
+  OpenApiSpec['paths']['/v3/firefox/global-recs']['get']['responses']['200'][
+    'content'
+  ]['application/json']['schema'];
+const validate = ajv.compile(schema);
+
+describe('response', () => {
+  it('ajv returns errors when bad objects', () => {
+    const valid = validate({});
+    expect(!valid).toBeTruthy();
+    // uncomment if you want info about how errors look
+    // throw validate.errors
+    expect((validate.errors as DefinedError[]).length).toBeGreaterThan(0);
+  });
+
+  describe('responseTransformer', () => {
+    // all fields are non-nullable, not much to test other than happy path
+    it('handles happy path results', async () => {
+      // the default mock is happy path, ensure this is handled
+      const graphResponse = await Recommendations({
+        // auth components and middlewares are unimportant to mocks
+        // just mock them
+        auth: { junk: 'junk' } as unknown as WebAuth,
+        consumer_key: 'junkConsumerKey',
+        forwardHeadersMiddleware: () => null,
+        // provide real variables
+        variables: {
+          count: 30,
+          locale: 'fr',
+          region: 'FR',
+        },
+      });
+
+      const res = responseTransformer(graphResponse);
+      const valid = validate(res);
+      if (valid) {
+        // any additional expectations can be defined here
+        expect(res.recommendations.length).toEqual(30);
+        expect(
+          res.recommendations[0].url.endsWith('utm_source=pocket-newtab-bff')
+        );
+      } else {
+        throw validate.errors;
+      }
+    });
+  });
+});

--- a/src/api/v3/response.ts
+++ b/src/api/v3/response.ts
@@ -1,0 +1,63 @@
+import { RecommendationsQuery } from '../../generated/graphql/types';
+import { components, paths } from '../../generated/openapi/types';
+import { Unpack } from '../../types';
+import { appendUtmSource } from '../desktop/recommendations/response';
+
+// unpack GraphQL generated types from RecommendationsQuery
+type GraphRecommendation = Unpack<
+  RecommendationsQuery['newTabSlate']['recommendations']
+>;
+
+// unpack exact OpenAPI generated types for API response
+export type GlobalRecsResponse =
+  paths['/v3/firefox/global-recs']['get']['responses']['200']['content']['application/json'];
+type LegacyFeedItem = components['schemas']['LegacyFeedItem'];
+
+export const mapRecommendation = (
+  recommendation: GraphRecommendation
+): LegacyFeedItem => {
+  const encodedImageUrl = encodeURIComponent(
+    recommendation.corpusItem.imageUrl
+  );
+
+  return {
+    id: recommendation.tileId,
+    url: appendUtmSource(recommendation.corpusItem.url),
+    title: recommendation.corpusItem.title,
+    excerpt: recommendation.corpusItem.excerpt,
+    domain: recommendation.corpusItem.publisher,
+    raw_image_src: recommendation.corpusItem.imageUrl,
+    image_src: `https://img-getpocket.cdn.mozilla.net/direct?url=${encodedImageUrl}&resize=w450`,
+  };
+};
+
+export const responseTransformer = (
+  recommendations: RecommendationsQuery
+): GlobalRecsResponse => {
+  return {
+    status: 1,
+    spocs: [],
+    settings: {
+      domainAffinityParameterSets: {},
+      timeSegments: [
+        {
+          id: 'week',
+          startTime: 604800,
+          endTime: 0,
+          weightPosition: 1,
+        },
+        {
+          id: 'month',
+          startTime: 2592000,
+          endTime: 604800,
+          weightPosition: 0.5,
+        },
+      ],
+      recsExpireTime: 5400,
+      spocsPerNewTabs: 0.5,
+      version: '6f605b0212069b4b8d3d040faf55742061a25c16',
+    },
+    recommendations:
+      recommendations.newTabSlate.recommendations.map(mapRecommendation),
+  };
+};

--- a/src/api/v3/response.ts
+++ b/src/api/v3/response.ts
@@ -55,6 +55,7 @@ export const responseTransformer = (
       ],
       recsExpireTime: 5400,
       spocsPerNewTabs: 0.5,
+      // version is a static, arbitrary hash to mimic the legacy response schema
       version: '6f605b0212069b4b8d3d040faf55742061a25c16',
     },
     recommendations:

--- a/src/generated/openapi/types.ts
+++ b/src/generated/openapi/types.ts
@@ -206,7 +206,7 @@ export interface operations {
         /** @description Maximum number of items to return */
       query: {
         version: number;
-        locale_lang?: string;
+        locale_lang: string;
         region?: string;
         count?: number;
       };

--- a/src/generated/openapi/types.ts
+++ b/src/generated/openapi/types.ts
@@ -12,11 +12,25 @@ type OneOf<T extends any[]> = T extends [infer Only] ? Only : T extends [infer A
 
 export interface paths {
   "/desktop/v1/recommendations": {
-    /** Gets a list of Recommendations for a Locale and Region. This operation is performed anonymously and requires no auth. */
+    /**
+     * Gets a list of Recommendations for a Locale and Region. This operation is performed anonymously and requires no auth. 
+     * @description Supports Fx desktop version 114 and up.
+     */
     get: operations["getRecommendations"];
   };
+  "/v3/firefox/global-recs": {
+    /**
+     * Used by older versions of Firefox to get a list of Recommendations for a Locale and Region. This operation is performed anonymously and requires no auth. 
+     * @deprecated 
+     * @description Supports Fx desktop version 115 and below.
+     */
+    get: operations["getGlobalRecs"];
+  };
   "/desktop/v1/recent-saves": {
-    /** Gets a list of the most recent saves for a specific user */
+    /**
+     * Gets a list of the most recent saves for a specific user. 
+     * @description Supports Fx desktop version 113 and up.
+     */
     get: operations["getRecentSaves"];
   };
 }
@@ -100,6 +114,27 @@ export interface components {
       /** @description The primary image for a Recommendation. */
       imageUrl: string;
     };
+    LegacyFeedItem: {
+      id: number;
+      title: string;
+      url: string;
+      excerpt: string;
+      domain: string;
+      image_src: string;
+      raw_image_src: string;
+    };
+    LegacySettings: {
+      spocsPerNewTabs?: number;
+      domainAffinityParameterSets?: Record<string, never>;
+      timeSegments?: ({
+          id: string;
+          startTime: number;
+          endTime: number;
+          weightPosition: number;
+        })[];
+      recsExpireTime?: number;
+      version?: string;
+    };
   };
   responses: never;
   parameters: never;
@@ -113,15 +148,18 @@ export type external = Record<string, never>;
 export interface operations {
 
   getRecommendations: {
-    /** Gets a list of Recommendations for a Locale and Region. This operation is performed anonymously and requires no auth. */
+    /**
+     * Gets a list of Recommendations for a Locale and Region. This operation is performed anonymously and requires no auth. 
+     * @description Supports Fx desktop version 114 and up.
+     */
     parameters: {
         /** @description The number of items to return. */
         /** @description This locale string is Fx domain language, and built from Fx expectations. Parameter values are not case sensitive. */
         /** @description This region string is Fx domain language, and built from Fx expectations. Parameter values are not case sensitive. */
       query: {
         count?: number;
-        locale: "fr" | "fr-FR" | "es" | "es-ES" | "it" | "it-IT";
-        region: "FR" | "ES" | "IT";
+        locale: "fr" | "fr-FR" | "es" | "es-ES" | "it" | "it-IT" | "en" | "en-CA" | "en-GB" | "en-US" | "de" | "de-DE" | "de-AT" | "de-CH";
+        region: "US" | "CA" | "DE" | "GB" | "IE" | "FR" | "ES" | "IT" | "IN" | "CH" | "AT" | "BE";
       };
     };
     responses: {
@@ -155,8 +193,64 @@ export interface operations {
       };
     };
   };
+  getGlobalRecs: {
+    /**
+     * Used by older versions of Firefox to get a list of Recommendations for a Locale and Region. This operation is performed anonymously and requires no auth. 
+     * @deprecated 
+     * @description Supports Fx desktop version 115 and below.
+     */
+    parameters: {
+        /** @description API version */
+        /** @description Firefox locale */
+        /** @description Firefox region */
+        /** @description Maximum number of items to return */
+      query: {
+        version: number;
+        locale_lang?: string;
+        region?: string;
+        count?: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "application/json": {
+            /** @enum {integer} */
+            status: 1;
+            spocs: (unknown)[];
+            settings: components["schemas"]["LegacySettings"];
+            recommendations: (components["schemas"]["LegacyFeedItem"])[];
+          };
+        };
+      };
+      /** @description Invalid request parameters */
+      400: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse"];
+        };
+      };
+      /** @description This proxy service encountered an unexpected error. */
+      500: never;
+      /** @description Services downstream from this proxy encountered an unexpected error. */
+      502: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse"];
+        };
+      };
+      /** @description Requests to downstream services timed out. */
+      504: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse"];
+        };
+      };
+    };
+  };
   getRecentSaves: {
-    /** Gets a list of the most recent saves for a specific user */
+    /**
+     * Gets a list of the most recent saves for a specific user. 
+     * @description Supports Fx desktop version 113 and up.
+     */
     parameters?: {
         /** @description The number of items to return. */
       query?: {


### PR DESCRIPTION
## Goal
Add a backward-compatible NewTab recommendation endpoint /v3/firefox/global-recs.

## I'd love feedback/perspectives on:
- Test coverage
- Naming conventions

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/DIS-841

Documentation:
* [Technical Spec](https://getpocket.atlassian.net/wiki/spaces/CP/pages/2981593146/Technical+Spec+Deprecate+Legacy+Firefox+Recommendations+API)
