### PR TITLE
fix(recommendations): [DIS-843] Make region optional and unvalidated

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -287,14 +287,10 @@ paths:
             ]
         - name: region
           in: query
-          required: true
-          description: This region string is Fx domain language, and built from Fx expectations. Parameter values are not case sensitive.
+          required: false
+          description: This region string is Fx domain language, and built from Fx expectations. Parameter values are not case sensitive. See [Firefox Home & New Tab Regional Differences](https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/80448805/Regional+Differences).
           schema:
             type: string
-            enum: [
-              # relevant docs: https://docs.google.com/document/d/1omclr-eETJ7zAWTMI7mvvsc3_-ns2Iiho4jPEfrmZfo
-              US, CA, DE, GB, IE, FR, ES, IT, IN, CH, AT, BE,
-            ]
       responses:
         '200':
           description: OK

--- a/src/api/desktop/recommendations/inputs.spec.ts
+++ b/src/api/desktop/recommendations/inputs.spec.ts
@@ -138,22 +138,12 @@ describe('input.ts recommendations query parameters', () => {
                 parameters: 'locale',
               },
             }),
-            expect.objectContaining<APIError>({
-              status: '400',
-              title: 'Bad Request',
-              detail:
-                'Region must be provided. Valid regions include [' +
-                '"US","CA","DE","GB","IE","FR","ES","IT","IN","CH","AT","BE"]',
-              source: {
-                parameters: 'region',
-              },
-            }),
           ]),
         })
       );
     });
 
-    it('region and locale are required', () => {
+    it('locale is required', () => {
       const res = validate({
         count: 30,
         // region and locale are missing
@@ -173,16 +163,6 @@ describe('input.ts recommendations query parameters', () => {
                 '"en-GB","en-US","de","de-DE","de-AT","de-CH"]',
               source: {
                 parameters: 'locale',
-              },
-            }),
-            expect.objectContaining<APIError>({
-              status: '400',
-              title: 'Bad Request',
-              detail:
-                'Region must be provided. Valid regions include [' +
-                '"US","CA","DE","GB","IE","FR","ES","IT","IN","CH","AT","BE"]',
-              source: {
-                parameters: 'region',
               },
             }),
           ]),

--- a/src/api/desktop/recommendations/inputs.ts
+++ b/src/api/desktop/recommendations/inputs.ts
@@ -78,44 +78,6 @@ const isValidLocale: ValidatorFunction = (locale?: string) =>
     }
     : null;
 
-// all valid regions
-const validRegions = [
-  'US',
-  'CA',
-  'DE',
-  'GB',
-  'IE',
-  'FR',
-  'ES',
-  'IT',
-  'IN',
-  'CH',
-  'AT',
-  'BE',
-];
-// copy to set for fast lookup, all lowercase
-const validRegionsSet = new Set(
-  validRegions.map((region) => region.toLowerCase())
-);
-
-// prettier config thrashes here
-// prettier-ignore
-/**
- * Validates regions. This ensures that region is present and
- * contains a valid value.
- *
- * Returns null if valid, or returns details to build an error
- * if invalid.
- * @param region
- */
-const isValidRegion: ValidatorFunction = (region?: string) =>
-  !validRegionsSet.has(region?.toLowerCase?.())
-    ? {
-      propertyName: 'region',
-      errorDetail: `Region must be provided. Valid regions include ${JSON.stringify(validRegions)}`,
-    }
-    : null;
-
 // prettier config thrashes here
 // prettier-ignore
 // returns details to build error response if invalid
@@ -174,7 +136,6 @@ export const validate = (
   const errorDetails = [
     isValidCount(query.count),
     isValidLocale(query.locale),
-    isValidRegion(query.region),
   ].filter((ed) => ed !== null);
 
   if (errorDetails.length > 0) {

--- a/src/generated/openapi/types.ts
+++ b/src/generated/openapi/types.ts
@@ -155,11 +155,11 @@ export interface operations {
     parameters: {
         /** @description The number of items to return. */
         /** @description This locale string is Fx domain language, and built from Fx expectations. Parameter values are not case sensitive. */
-        /** @description This region string is Fx domain language, and built from Fx expectations. Parameter values are not case sensitive. */
+        /** @description This region string is Fx domain language, and built from Fx expectations. Parameter values are not case sensitive. See [Firefox Home & New Tab Regional Differences](https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/80448805/Regional+Differences). */
       query: {
         count?: number;
         locale: "fr" | "fr-FR" | "es" | "es-ES" | "it" | "it-IT" | "en" | "en-CA" | "en-GB" | "en-US" | "de" | "de-DE" | "de-AT" | "de-CH";
-        region: "US" | "CA" | "DE" | "GB" | "IE" | "FR" | "ES" | "IT" | "IN" | "CH" | "AT" | "BE";
+        region?: string;
       };
     };
     responses: {


### PR DESCRIPTION
## Goal
Remove region validation. When people change region, Firefox might send a request from an unsupported region, and that should not result in an error in Firefox.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/DIS-843

Slack thread:
* https://mozilla.slack.com/archives/C04LKH4J1M0/p1689806475066019