### PR TITLE
feat(utmSource): [DIS-844] Add utm source dynamically to the url

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -52,7 +52,7 @@ components:
           type: array
           items:
             oneOf:
-              - $ref: "#/components/schemas/Error"
+              - $ref: '#/components/schemas/Error'
     Save:
       type: object
       required:
@@ -255,8 +255,8 @@ paths:
       operationId: getRecommendations
       # Intentionally blank security. No auth required.
       security:
-        - WSConsumerKeyAuth: [ ]
-        - WSConsumerKeyAuthAlias: [ ]
+        - WSConsumerKeyAuth: []
+        - WSConsumerKeyAuthAlias: []
       parameters:
         - name: count
           in: query
@@ -275,22 +275,46 @@ paths:
           schema:
             type: string
             enum: [
-              # relevant docs: https://docs.google.com/document/d/1omclr-eETJ7zAWTMI7mvvsc3_-ns2Iiho4jPEfrmZfo
+                # relevant docs: https://docs.google.com/document/d/1omclr-eETJ7zAWTMI7mvvsc3_-ns2Iiho4jPEfrmZfo
 
-              # fr, es, it are served through this API in Firefox 114,
-              # and we plan to migrate all NewTab markets in Firefox 116:
-              fr, fr-FR,
-              es, es-ES,
-              it, it-IT,
-              en, en-CA, en-GB, en-US,
-              de, de-DE, de-AT, de-CH,
-            ]
+                # fr, es, it are served through this API in Firefox 114,
+                # and we plan to migrate all NewTab markets in Firefox 116:
+                fr,
+                fr-FR,
+                es,
+                es-ES,
+                it,
+                it-IT,
+                en,
+                en-CA,
+                en-GB,
+                en-US,
+                de,
+                de-DE,
+                de-AT,
+                de-CH,
+              ]
         - name: region
           in: query
           required: false
           description: This region string is Fx domain language, and built from Fx expectations. Parameter values are not case sensitive. See [Firefox Home & New Tab Regional Differences](https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/80448805/Regional+Differences).
           schema:
             type: string
+            enum: [
+                # relevant docs: https://docs.google.com/document/d/1omclr-eETJ7zAWTMI7mvvsc3_-ns2Iiho4jPEfrmZfo
+                US,
+                CA,
+                DE,
+                GB,
+                IE,
+                FR,
+                ES,
+                IT,
+                IN,
+                CH,
+                AT,
+                BE,
+              ]
       responses:
         '200':
           description: OK
@@ -305,13 +329,13 @@ paths:
                     type: array
                     items:
                       oneOf:
-                        - $ref: "#/components/schemas/Recommendation"
+                        - $ref: '#/components/schemas/Recommendation'
         '400':
           description: Invalid request parameters
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: This proxy service encountered an unexpected error.
         '502':
@@ -319,13 +343,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         '504':
           description: Requests to downstream services timed out.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
   /v3/firefox/global-recs:
     get:
       deprecated: true
@@ -334,8 +358,8 @@ paths:
       operationId: getGlobalRecs
       # Intentionally blank security. No auth required.
       security:
-        - WSConsumerKeyAuth: [ ]
-        - WSConsumerKeyAuthAlias: [ ]
+        - WSConsumerKeyAuth: []
+        - WSConsumerKeyAuthAlias: []
       parameters:
         - in: query
           name: version
@@ -388,17 +412,17 @@ paths:
                   spocs:
                     type: array
                   settings:
-                    $ref: "#/components/schemas/LegacySettings"
+                    $ref: '#/components/schemas/LegacySettings'
                   recommendations:
                     type: array
                     items:
-                      $ref: "#/components/schemas/LegacyFeedItem"
+                      $ref: '#/components/schemas/LegacyFeedItem'
         '400':
           description: Invalid request parameters
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: This proxy service encountered an unexpected error.
         '502':
@@ -406,13 +430,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         '504':
           description: Requests to downstream services timed out.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
   /desktop/v1/recent-saves:
     get:
       summary: Gets a list of the most recent saves for a specific user.
@@ -420,14 +444,14 @@ paths:
       operationId: getRecentSaves
       security:
         # require all WS (WebSession) security schemes together
-        - WSUserAuth: [ ]
-          WSSessionAuth: [ ]
-          WSLookupAuth: [ ]
-          WSConsumerKeyAuth: [ ]
-        - WSUserAuth: [ ]
-          WSSessionAuth: [ ]
-          WSLookupAuth: [ ]
-          WSConsumerKeyAuthAlias: [ ]
+        - WSUserAuth: []
+          WSSessionAuth: []
+          WSLookupAuth: []
+          WSConsumerKeyAuth: []
+        - WSUserAuth: []
+          WSSessionAuth: []
+          WSLookupAuth: []
+          WSConsumerKeyAuthAlias: []
       parameters:
         - name: count
           in: query
@@ -454,20 +478,20 @@ paths:
                     type: array
                     items:
                       oneOf:
-                        - $ref: "#/components/schemas/Save"
-                        - $ref: "#/components/schemas/PendingSave"
+                        - $ref: '#/components/schemas/Save'
+                        - $ref: '#/components/schemas/PendingSave'
         '400':
           description: Invalid request parameters
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         '401':
           description: Authorization is missing or invalid.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: This proxy service encountered an unexpected error.
         '502':
@@ -475,10 +499,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'
         '504':
           description: Requests to downstream services timed out.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponse"
+                $ref: '#/components/schemas/ErrorResponse'

--- a/src/api/desktop/recommendations/index.ts
+++ b/src/api/desktop/recommendations/index.ts
@@ -7,7 +7,7 @@ import { handleQueryParameters } from './inputs';
 import { BFFFxError } from '../../../bfffxError';
 import Recommendations from '../../../graphql-proxy/recommendations/recommendations';
 import { forwardHeadersMiddleware } from '../../../graphql-proxy/lib/client';
-import { RecommendationsQueryVariables } from '../../../generated/graphql/types';
+import { NewTabRecommendationsQueryVariables } from '../../../generated/graphql/types';
 import { RecommendationsResponse, responseTransformer } from './response';
 
 const router = express.Router();
@@ -29,7 +29,7 @@ router.get(
         auth: req.auth,
         consumer_key: req.consumer_key,
         forwardHeadersMiddleware: forwardHeadersMiddleware(res),
-        variables: variables as RecommendationsQueryVariables,
+        variables: variables as NewTabRecommendationsQueryVariables,
       });
 
       res.json(responseTransformer(graphRes) as RecommendationsResponse);

--- a/src/api/desktop/recommendations/inputs.spec.ts
+++ b/src/api/desktop/recommendations/inputs.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import assert from 'assert';
 
-import { RecommendationsQueryVariables } from '../../../generated/graphql/types';
+import { NewTabRecommendationsQueryVariables } from '../../../generated/graphql/types';
 import {
   handleQueryParameters,
   setDefaultsAndCoerceTypes,
@@ -201,7 +201,7 @@ describe('input.ts recommendations query parameters', () => {
 
       const variables = handleQueryParameters(params);
       expect(variables).toStrictEqual(
-        expect.objectContaining<RecommendationsQueryVariables>({
+        expect.objectContaining<NewTabRecommendationsQueryVariables>({
           count: parseInt(params.count, 10),
           locale: params.locale,
           region: params.region,

--- a/src/api/desktop/recommendations/inputs.ts
+++ b/src/api/desktop/recommendations/inputs.ts
@@ -9,7 +9,7 @@
 
 import { paths } from '../../../generated/openapi/types';
 import { ToStringParams } from '../../../types';
-import { RecommendationsQueryVariables } from '../../../generated/graphql/types';
+import { NewTabRecommendationsQueryVariables } from '../../../generated/graphql/types';
 import { BFFFxError, BFFFxErrorInstanceType } from '../../../bfffxError';
 
 export type RecommendationsQueryParameters =
@@ -167,7 +167,7 @@ export const validate = (
  *
  * Parses query parameter strings as provided by express.req.query,
  * sets defaults, validates them, and transforms them into
- * RecommendationsQueryVariables for the GraphQL client.
+ * NewTabRecommendationsQueryVariables for the GraphQL client.
  *
  * This returns a discriminated union that includes errors. Be sure
  * to check for them and return them to the client if present.
@@ -175,7 +175,7 @@ export const validate = (
  */
 export const handleQueryParameters = (
   query: RecommendationsQueryParameterStrings
-): RecommendationsQueryVariables | BFFFxErrorInstanceType => {
+): NewTabRecommendationsQueryVariables | BFFFxErrorInstanceType => {
   const coerced = setDefaultsAndCoerceTypes(query);
   const maybeValid = validate(coerced);
 
@@ -183,5 +183,5 @@ export const handleQueryParameters = (
     return maybeValid;
   }
 
-  return maybeValid as RecommendationsQueryVariables;
+  return maybeValid as NewTabRecommendationsQueryVariables;
 };

--- a/src/api/desktop/recommendations/response.spec.ts
+++ b/src/api/desktop/recommendations/response.spec.ts
@@ -47,7 +47,11 @@ describe('response', () => {
       if (valid) {
         // any additional expectations can be defined here
         expect(res.data.length).toEqual(30);
-        expect(res.data[0].url.endsWith('utm_source=pocket-newtab-bff'));
+        expect(
+          res.data[0].url.endsWith(
+            `utm_source=${graphResponse.newTabSlate.utmSource}`
+          )
+        ).toBeTruthy();
       } else {
         throw validate.errors;
       }
@@ -57,28 +61,28 @@ describe('response', () => {
   describe('appendUtmSource', () => {
     it('should add a utm_source query parameter when input URL does not have any query parameters', () => {
       const url = 'https://example.com';
-      const expected = 'https://example.com/?utm_source=pocket-newtab-bff';
-      expect(appendUtmSource(url)).toBe(expected);
+      const expected = 'https://example.com/?utm_source=pocket-test-utm';
+      expect(appendUtmSource(url, 'pocket-test-utm')).toBe(expected);
     });
 
     it('should add a utm_source query parameter when the input URL already has a query parameter', () => {
       const url = 'https://example.com?foo=bar';
       const expected =
-        'https://example.com/?foo=bar&utm_source=pocket-newtab-bff';
-      expect(appendUtmSource(url)).toBe(expected);
+        'https://example.com/?foo=bar&utm_source=pocket-test-utm';
+      expect(appendUtmSource(url, 'pocket-test-utm')).toBe(expected);
     });
 
     it('should add utm_source query parameter when the input URL ends with a fragment', () => {
       const url = 'https://example.com#my-fragment';
       const expected =
-        'https://example.com/?utm_source=pocket-newtab-bff#my-fragment';
-      expect(appendUtmSource(url)).toBe(expected);
+        'https://example.com/?utm_source=pocket-test-utm#my-fragment';
+      expect(appendUtmSource(url, 'pocket-test-utm')).toBe(expected);
     });
 
     it('should override utm_source query parameter if the url already contains utm_source', () => {
       const url = 'https://example.com/?utm_source=fgfeed';
-      const expected = 'https://example.com/?utm_source=pocket-newtab-bff';
-      expect(appendUtmSource(url)).toBe(expected);
+      const expected = 'https://example.com/?utm_source=pocket-test-utm';
+      expect(appendUtmSource(url, 'pocket-test-utm')).toBe(expected);
     });
   });
 });

--- a/src/api/desktop/recommendations/response.ts
+++ b/src/api/desktop/recommendations/response.ts
@@ -27,9 +27,9 @@ export const appendUtmSource = (url: string, utmSource: string): string => {
 };
 
 /**
- * Validates the utmSource and logs error if falsey.
+ * Validates the utmSource. logs error if falsey and sets it to a default value.
  */
-export const validateAndSetDefaultUtmSource = (utmSource?: string): string => {
+export const validateAndSetUtmSource = (utmSource?: string): string => {
   if (!utmSource) {
     Logger(
       'utmSource is undefined or null. Setting it to pocket-newtab'
@@ -44,19 +44,13 @@ export const mapRecommendation = (
   recommendation: GraphRecommendation,
   utmSource: string
 ): Recommendation => {
-  if (!utmSource) {
-    // Log error if utmSource is not received and set it to a default value.
-    Logger(
-      'utmSource is undefined or null. Setting it to pocket-newtab'
-    ).error();
-
-    utmSource = 'pocket-newtab';
-  }
-
   return {
     __typename: 'Recommendation',
     tileId: recommendation.tileId,
-    url: appendUtmSource(recommendation.corpusItem.url, utmSource),
+    url: appendUtmSource(
+      recommendation.corpusItem.url,
+      validateAndSetUtmSource(utmSource)
+    ),
     title: recommendation.corpusItem.title,
     excerpt: recommendation.corpusItem.excerpt,
     publisher: recommendation.corpusItem.publisher,

--- a/src/api/v3/index.ts
+++ b/src/api/v3/index.ts
@@ -7,7 +7,7 @@ import { handleQueryParameters } from './inputs';
 import { BFFFxError } from '../../bfffxError';
 import Recommendations from '../../graphql-proxy/recommendations/recommendations';
 import { forwardHeadersMiddleware } from '../../graphql-proxy/lib/client';
-import { RecommendationsQueryVariables } from '../../generated/graphql/types';
+import { NewTabRecommendationsQueryVariables } from '../../generated/graphql/types';
 import { GlobalRecsResponse, responseTransformer } from './response';
 
 const router = express.Router();
@@ -29,7 +29,7 @@ router.get(
         auth: req.auth,
         consumer_key: req.consumer_key,
         forwardHeadersMiddleware: forwardHeadersMiddleware(res),
-        variables: variables as RecommendationsQueryVariables,
+        variables: variables as NewTabRecommendationsQueryVariables,
       });
 
       res.json(responseTransformer(graphRes) as GlobalRecsResponse);

--- a/src/api/v3/inputs.spec.ts
+++ b/src/api/v3/inputs.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import assert from 'assert';
 
-import { RecommendationsQueryVariables } from '../../generated/graphql/types';
+import { NewTabRecommendationsQueryVariables } from '../../generated/graphql/types';
 import {
   GlobalRecsQueryParameterStrings,
   handleQueryParameters,
@@ -64,7 +64,7 @@ describe('input.ts recommendations query parameters', () => {
 
       const variables = handleQueryParameters(params);
       expect(variables).toStrictEqual(
-        expect.objectContaining<RecommendationsQueryVariables>({
+        expect.objectContaining<NewTabRecommendationsQueryVariables>({
           count: parseInt(params.count, 10),
           locale: params.locale_lang,
           region: params.region,

--- a/src/api/v3/inputs.ts
+++ b/src/api/v3/inputs.ts
@@ -9,7 +9,7 @@
 
 import { paths } from '../../generated/openapi/types';
 import { ToStringParams } from '../../types';
-import { RecommendationsQueryVariables } from '../../generated/graphql/types';
+import { NewTabRecommendationsQueryVariables } from '../../generated/graphql/types';
 import { BFFFxError, BFFFxErrorInstanceType } from '../../bfffxError';
 import { validate } from '../desktop/recommendations/inputs';
 
@@ -54,7 +54,7 @@ export const setDefaultsAndCoerceTypes = (
  *
  * Parses query parameter strings as provided by express.req.query,
  * sets defaults, validates them, and transforms them into
- * RecommendationsQueryVariables for the GraphQL client.
+ * NewTabRecommendationsQueryVariables for the GraphQL client.
  *
  * This returns a discriminated union that includes errors. Be sure
  * to check for them and return them to the client if present.
@@ -62,7 +62,7 @@ export const setDefaultsAndCoerceTypes = (
  */
 export const handleQueryParameters = (
   query: GlobalRecsQueryParameterStrings
-): RecommendationsQueryVariables | BFFFxErrorInstanceType => {
+): NewTabRecommendationsQueryVariables | BFFFxErrorInstanceType => {
   const coerced = setDefaultsAndCoerceTypes(query);
   const maybeValid = validate(coerced);
 
@@ -70,5 +70,5 @@ export const handleQueryParameters = (
     return maybeValid;
   }
 
-  return maybeValid as RecommendationsQueryVariables;
+  return maybeValid as NewTabRecommendationsQueryVariables;
 };

--- a/src/api/v3/response.spec.ts
+++ b/src/api/v3/response.spec.ts
@@ -48,8 +48,10 @@ describe('response', () => {
         // any additional expectations can be defined here
         expect(res.recommendations.length).toEqual(30);
         expect(
-          res.recommendations[0].url.endsWith('utm_source=pocket-newtab-bff')
-        );
+          res.recommendations[0].url.endsWith(
+            `utm_source=${graphResponse.newTabSlate.utmSource}`
+          )
+        ).toBeTruthy();
       } else {
         throw validate.errors;
       }

--- a/src/api/v3/response.ts
+++ b/src/api/v3/response.ts
@@ -1,11 +1,14 @@
-import { RecommendationsQuery } from '../../generated/graphql/types';
+import { NewTabRecommendationsQuery } from '../../generated/graphql/types';
 import { components, paths } from '../../generated/openapi/types';
 import { Unpack } from '../../types';
-import { appendUtmSource } from '../desktop/recommendations/response';
+import {
+  appendUtmSource,
+  validateAndSetDefaultUtmSource,
+} from '../desktop/recommendations/response';
 
-// unpack GraphQL generated types from RecommendationsQuery
+// unpack GraphQL generated types from NewTabRecommendationsQuery
 type GraphRecommendation = Unpack<
-  RecommendationsQuery['newTabSlate']['recommendations']
+  NewTabRecommendationsQuery['newTabSlate']['recommendations']
 >;
 
 // unpack exact OpenAPI generated types for API response
@@ -14,7 +17,8 @@ export type GlobalRecsResponse =
 type LegacyFeedItem = components['schemas']['LegacyFeedItem'];
 
 export const mapRecommendation = (
-  recommendation: GraphRecommendation
+  recommendation: GraphRecommendation,
+  utmSource: string
 ): LegacyFeedItem => {
   const encodedImageUrl = encodeURIComponent(
     recommendation.corpusItem.imageUrl
@@ -22,7 +26,10 @@ export const mapRecommendation = (
 
   return {
     id: recommendation.tileId,
-    url: appendUtmSource(recommendation.corpusItem.url),
+    url: appendUtmSource(
+      recommendation.corpusItem.url,
+      validateAndSetDefaultUtmSource(utmSource)
+    ),
     title: recommendation.corpusItem.title,
     excerpt: recommendation.corpusItem.excerpt,
     domain: recommendation.corpusItem.publisher,
@@ -32,7 +39,7 @@ export const mapRecommendation = (
 };
 
 export const responseTransformer = (
-  recommendations: RecommendationsQuery
+  recommendations: NewTabRecommendationsQuery
 ): GlobalRecsResponse => {
   return {
     status: 1,
@@ -58,7 +65,13 @@ export const responseTransformer = (
       // version is a static, arbitrary hash to mimic the legacy response schema
       version: '6f605b0212069b4b8d3d040faf55742061a25c16',
     },
-    recommendations:
-      recommendations.newTabSlate.recommendations.map(mapRecommendation),
+    recommendations: recommendations.newTabSlate.recommendations.map(
+      (recommendation) => {
+        return mapRecommendation(
+          recommendation,
+          recommendations.newTabSlate.utmSource
+        );
+      }
+    ),
   };
 };

--- a/src/api/v3/response.ts
+++ b/src/api/v3/response.ts
@@ -3,7 +3,7 @@ import { components, paths } from '../../generated/openapi/types';
 import { Unpack } from '../../types';
 import {
   appendUtmSource,
-  validateAndSetDefaultUtmSource,
+  validateAndSetUtmSource,
 } from '../desktop/recommendations/response';
 
 // unpack GraphQL generated types from NewTabRecommendationsQuery
@@ -28,7 +28,7 @@ export const mapRecommendation = (
     id: recommendation.tileId,
     url: appendUtmSource(
       recommendation.corpusItem.url,
-      validateAndSetDefaultUtmSource(utmSource)
+      validateAndSetUtmSource(utmSource)
     ),
     title: recommendation.corpusItem.title,
     excerpt: recommendation.corpusItem.excerpt,

--- a/src/graphql-proxy/recommendations/Recommendations.graphql
+++ b/src/graphql-proxy/recommendations/Recommendations.graphql
@@ -1,5 +1,6 @@
 query NewTabRecommendations($locale: String!, $region: String, $count: Int) {
   newTabSlate(locale: $locale, region: $region) {
+    utmSource
     recommendations(count: $count) {
       tileId
       corpusItem {

--- a/src/graphql-proxy/recommendations/__mocks__/recommendations.ts
+++ b/src/graphql-proxy/recommendations/__mocks__/recommendations.ts
@@ -8,7 +8,7 @@ import { faker } from '@faker-js/faker';
 
 import common from '../../__mocks__/common';
 
-import { RecommendationsQuery } from '../../../generated/graphql/types';
+import { NewTabRecommendationsQuery } from '../../../generated/graphql/types';
 import { RecommendationsParameters } from '../recommendations';
 
 /**
@@ -27,7 +27,7 @@ const fakerLocales = {
 
 const fakeRecommendations = (
   count
-): RecommendationsQuery['newTabSlate']['recommendations'] => {
+): NewTabRecommendationsQuery['newTabSlate']['recommendations'] => {
   return Array(count)
     .fill(0)
     .map(() => ({
@@ -48,7 +48,7 @@ const recommendations = async ({
   consumer_key,
   forwardHeadersMiddleware,
   variables,
-}: RecommendationsParameters): Promise<RecommendationsQuery> => {
+}: RecommendationsParameters): Promise<NewTabRecommendationsQuery> => {
   // set faker locale based on variables
   // default to english if unrecognized, roughly matches graph behavior selecting locale.
   const fakerLocale = fakerLocales[variables.locale.toLowerCase()] ?? 'en';
@@ -57,6 +57,7 @@ const recommendations = async ({
   const response = {
     newTabSlate: {
       recommendations: fakeRecommendations(variables.count),
+      utmSource: `pocket-newtab-${fakerLocale}`,
     },
   };
 

--- a/src/graphql-proxy/recommendations/recommendations.ts
+++ b/src/graphql-proxy/recommendations/recommendations.ts
@@ -1,9 +1,9 @@
 import { webProxyClient } from '../lib/client';
 
 import {
-  RecommendationsDocument,
-  RecommendationsQuery,
-  RecommendationsQueryVariables,
+  NewTabRecommendationsDocument,
+  NewTabRecommendationsQuery,
+  NewTabRecommendationsQueryVariables,
 } from '../../generated/graphql/types';
 import { ClientParameters } from '../types';
 
@@ -11,7 +11,7 @@ import { ClientParameters } from '../types';
  * recommendations.ts GraphQL client request parameters
  */
 export type RecommendationsParameters =
-  ClientParameters<RecommendationsQueryVariables>;
+  ClientParameters<NewTabRecommendationsQueryVariables>;
 
 /**
  * This client performs the query specified in Recommendations.graphql, utilizing
@@ -31,10 +31,10 @@ const Recommendations = async ({
   const client = webProxyClient(consumer_key, forwardHeadersMiddleware);
   auth.authenticateClient(client);
 
-  return client.request<RecommendationsQuery, RecommendationsQueryVariables>(
-    RecommendationsDocument,
-    variables
-  );
+  return client.request<
+    NewTabRecommendationsQuery,
+    NewTabRecommendationsQueryVariables
+  >(NewTabRecommendationsDocument, variables);
 };
 
 export default Recommendations;


### PR DESCRIPTION
## Goal
Setting the `utm_source` parameter to what is received from the gql response. Defaulting to `pocket-newtab` if nullish and logging an error as it shouldn't be nullish.

## I'd love feedback/perspectives on:
- Everything and anything.
- Most of the changes are renaming the new tab gql query.

JIRA ticket:
* [DIS-844](https://getpocket.atlassian.net/browse/DIS-844)


[DIS-844]: https://getpocket.atlassian.net/browse/DIS-844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ