### PR TITLE
feat(timeToRead): [DIS-852] Add time_to_read / timeToRead

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -152,6 +152,9 @@ components:
         imageUrl:
           type: string
           description: The primary image for a Recommendation.
+        timeToRead:
+          type: integer
+          description: Article read time in minutes
 
     LegacyFeedItem:
       type: object
@@ -178,6 +181,8 @@ components:
           type: string
         raw_image_src:
           type: string
+        time_to_read:
+          type: integer
 
     LegacySettings:
       type: object
@@ -300,21 +305,6 @@ paths:
           description: This region string is Fx domain language, and built from Fx expectations. Parameter values are not case sensitive. See [Firefox Home & New Tab Regional Differences](https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/80448805/Regional+Differences).
           schema:
             type: string
-            enum: [
-                # relevant docs: https://docs.google.com/document/d/1omclr-eETJ7zAWTMI7mvvsc3_-ns2Iiho4jPEfrmZfo
-                US,
-                CA,
-                DE,
-                GB,
-                IE,
-                FR,
-                ES,
-                IT,
-                IN,
-                CH,
-                AT,
-                BE,
-              ]
       responses:
         '200':
           description: OK

--- a/src/api/desktop/recommendations/recommendations.spec.ts
+++ b/src/api/desktop/recommendations/recommendations.spec.ts
@@ -89,5 +89,8 @@ describe('recommendations API server', () => {
     expect(recommendation.tileId).toEqual(
       mockResponse.newTabSlate.recommendations[0].tileId
     );
+    if (recommendation.timeToRead !== undefined) {
+      expect(recommendation.timeToRead).toBeGreaterThanOrEqual(1);
+    }
   });
 });

--- a/src/api/desktop/recommendations/response.spec.ts
+++ b/src/api/desktop/recommendations/response.spec.ts
@@ -52,6 +52,11 @@ describe('response', () => {
             `utm_source=${graphResponse.newTabSlate.utmSource}`
           )
         ).toBeTruthy();
+        // Even recommendations have timeToRead mocked to [1, 9].
+        expect(res.data[0].timeToRead).toBeGreaterThanOrEqual(1);
+        expect(res.data[0].timeToRead).toBeLessThanOrEqual(9);
+        // Odd recommendations have timeToRead mocked to undefined.
+        expect(res.data[1].timeToRead).toBeUndefined();
       } else {
         throw validate.errors;
       }

--- a/src/api/desktop/recommendations/response.ts
+++ b/src/api/desktop/recommendations/response.ts
@@ -4,7 +4,7 @@ import { Logger } from '../../../logger';
 import { Unpack } from '../../../types';
 
 // unpack GraphQL generated type for 'recommendations' from NewTabRecommendationsQuery
-type GraphRecommendation = Unpack<
+export type GraphRecommendation = Unpack<
   NewTabRecommendationsQuery['newTabSlate']['recommendations']
 >;
 
@@ -44,7 +44,7 @@ export const mapRecommendation = (
   recommendation: GraphRecommendation,
   utmSource: string
 ): Recommendation => {
-  return {
+  const recommendationToReturn: Recommendation = {
     __typename: 'Recommendation',
     tileId: recommendation.tileId,
     url: appendUtmSource(
@@ -56,6 +56,15 @@ export const mapRecommendation = (
     publisher: recommendation.corpusItem.publisher,
     imageUrl: recommendation.corpusItem.imageUrl,
   };
+
+  if (recommendation.corpusItem.timeToRead) {
+    return {
+      ...recommendationToReturn,
+      timeToRead: recommendation.corpusItem.timeToRead,
+    };
+  }
+
+  return recommendationToReturn;
 };
 
 export const responseTransformer = (

--- a/src/api/v3/recommendations.spec.ts
+++ b/src/api/v3/recommendations.spec.ts
@@ -64,7 +64,7 @@ describe('v3 legacy recommendations API server', () => {
 
     expect(res.status).toEqual(200);
 
-    // response ins json
+    // response is json
     const parsedRes = JSON.parse(res.text);
     expect(parsedRes.recommendations?.length).toEqual(1);
     const recommendation: LegacyFeedItem = parsedRes.recommendations[0];
@@ -74,5 +74,8 @@ describe('v3 legacy recommendations API server', () => {
     expect(recommendation.id).toEqual(
       mockResponse.newTabSlate.recommendations[0].tileId
     );
+    if (recommendation.time_to_read !== undefined) {
+      expect(recommendation.time_to_read).toBeGreaterThanOrEqual(1);
+    }
   });
 });

--- a/src/api/v3/response.spec.ts
+++ b/src/api/v3/response.spec.ts
@@ -52,6 +52,11 @@ describe('response', () => {
             `utm_source=${graphResponse.newTabSlate.utmSource}`
           )
         ).toBeTruthy();
+        // Even recommendations have timeToRead mocked to [1, 9].
+        expect(res.recommendations[0].time_to_read).toBeGreaterThanOrEqual(1);
+        expect(res.recommendations[0].time_to_read).toBeLessThanOrEqual(9);
+        // Odd recommendations have timeToRead mocked to undefined.
+        expect(res.recommendations[1].time_to_read).toBeUndefined();
       } else {
         throw validate.errors;
       }

--- a/src/api/v3/response.ts
+++ b/src/api/v3/response.ts
@@ -24,7 +24,7 @@ export const mapRecommendation = (
     recommendation.corpusItem.imageUrl
   );
 
-  return {
+  const feedItemToReturn: LegacyFeedItem = {
     id: recommendation.tileId,
     url: appendUtmSource(
       recommendation.corpusItem.url,
@@ -36,6 +36,15 @@ export const mapRecommendation = (
     raw_image_src: recommendation.corpusItem.imageUrl,
     image_src: `https://img-getpocket.cdn.mozilla.net/direct?url=${encodedImageUrl}&resize=w450`,
   };
+
+  if (recommendation.corpusItem.timeToRead) {
+    return {
+      ...feedItemToReturn,
+      time_to_read: recommendation.corpusItem.timeToRead,
+    };
+  }
+
+  return feedItemToReturn;
 };
 
 export const responseTransformer = (

--- a/src/generated/graphql/types.ts
+++ b/src/generated/graphql/types.ts
@@ -245,6 +245,8 @@ export type CorpusItem = {
   shortUrl?: Maybe<Scalars['Url']>;
   /** If the Corpus Item is pocket owned with a specific type, this is the associated object (Collection or SyndicatedArticle). */
   target?: Maybe<CorpusTarget>;
+  /** Time to read in minutes. Is nullable. */
+  timeToRead?: Maybe<Scalars['Int']>;
   /** The title of the Approved Item. */
   title: Scalars['String'];
   /** The topic associated with the Approved Item. */
@@ -428,6 +430,14 @@ export type DomainMetadata = {
   /** The name of the domain (e.g., The New York Times) */
   name?: Maybe<Scalars['String']>;
 };
+
+/** The reason a user web session is being expired. */
+export enum ExpireUserWebSessionReason {
+  /** Expire web session upon logging out. */
+  Logout = 'LOGOUT',
+  /** Expire web session on account password change. */
+  PasswordChanged = 'PASSWORD_CHANGED'
+}
 
 /** Input field to boost the score of an elasticsearch document based on a specific field and value */
 export type FunctionalBoostField = {
@@ -873,6 +883,12 @@ export type Mutation = {
    */
   deleteUserByFxaId: Scalars['ID'];
   /**
+   * Expires a user's web session tokens by firefox account ID.
+   * Called by fxa-webhook proxy. Need to supply a reason why to expire user web session.
+   * Returns the user ID.
+   */
+  expireUserWebSessionByFxaId: Scalars['ID'];
+  /**
    * temporary mutation for apple user migration.
    * called by fxa-webhook proxy to update the fxaId and email of the user.
    * Returns the pocket userId on success
@@ -1083,6 +1099,13 @@ export type MutationDeleteTagArgs = {
 /** Default Mutation Type */
 export type MutationDeleteUserByFxaIdArgs = {
   id: Scalars['ID'];
+};
+
+
+/** Default Mutation Type */
+export type MutationExpireUserWebSessionByFxaIdArgs = {
+  id: Scalars['ID'];
+  reason: ExpireUserWebSessionReason;
 };
 
 
@@ -2800,6 +2823,8 @@ export type User = {
   email?: Maybe<Scalars['String']>;
   /** The users first name */
   firstName?: Maybe<Scalars['String']>;
+  /** Indicates if a user is FxA or not */
+  isFxa?: Maybe<Scalars['Boolean']>;
   /** The user's premium status */
   isPremium?: Maybe<Scalars['Boolean']>;
   /** The users last name */
@@ -2938,8 +2963,8 @@ export type NewTabRecommendationsQueryVariables = Exact<{
 }>;
 
 
-export type NewTabRecommendationsQuery = { __typename?: 'Query', newTabSlate: { __typename?: 'CorpusSlate', utmSource?: string | null, recommendations: Array<{ __typename?: 'CorpusRecommendation', tileId: number, corpusItem: { __typename?: 'CorpusItem', excerpt: string, imageUrl: any, publisher: string, title: string, url: any } }> } };
+export type NewTabRecommendationsQuery = { __typename?: 'Query', newTabSlate: { __typename?: 'CorpusSlate', utmSource?: string | null, recommendations: Array<{ __typename?: 'CorpusRecommendation', tileId: number, corpusItem: { __typename?: 'CorpusItem', excerpt: string, imageUrl: any, publisher: string, title: string, url: any, timeToRead?: number | null } }> } };
 
 
 export const RecentSavesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"RecentSaves"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"pagination"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"PaginationInput"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"savedItems"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"pagination"},"value":{"kind":"Variable","name":{"kind":"Name","value":"pagination"}}},{"kind":"Argument","name":{"kind":"Name","value":"filter"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"statuses"},"value":{"kind":"ListValue","values":[{"kind":"EnumValue","value":"UNREAD"}]}}]}},{"kind":"Argument","name":{"kind":"Name","value":"sort"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"sortBy"},"value":{"kind":"EnumValue","value":"CREATED_AT"}},{"kind":"ObjectField","name":{"kind":"Name","value":"sortOrder"},"value":{"kind":"EnumValue","value":"DESC"}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"edges"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"cursor"}},{"kind":"Field","name":{"kind":"Name","value":"node"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"item"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"__typename"}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Item"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"wordCount"}},{"kind":"Field","name":{"kind":"Name","value":"topImage"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"url"}}]}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"timeToRead"}},{"kind":"Field","name":{"kind":"Name","value":"resolvedUrl"}},{"kind":"Field","name":{"kind":"Name","value":"givenUrl"}},{"kind":"Field","name":{"kind":"Name","value":"excerpt"}},{"kind":"Field","name":{"kind":"Name","value":"domain"}}]}}]}}]}}]}}]}}]}}]}}]} as unknown as DocumentNode<RecentSavesQuery, RecentSavesQueryVariables>;
-export const NewTabRecommendationsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"NewTabRecommendations"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"locale"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"region"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"count"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"newTabSlate"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"locale"},"value":{"kind":"Variable","name":{"kind":"Name","value":"locale"}}},{"kind":"Argument","name":{"kind":"Name","value":"region"},"value":{"kind":"Variable","name":{"kind":"Name","value":"region"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"utmSource"}},{"kind":"Field","name":{"kind":"Name","value":"recommendations"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"count"},"value":{"kind":"Variable","name":{"kind":"Name","value":"count"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tileId"}},{"kind":"Field","name":{"kind":"Name","value":"corpusItem"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"excerpt"}},{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"publisher"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"url"}}]}}]}}]}}]}}]} as unknown as DocumentNode<NewTabRecommendationsQuery, NewTabRecommendationsQueryVariables>;
+export const NewTabRecommendationsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"NewTabRecommendations"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"locale"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"region"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"count"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"newTabSlate"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"locale"},"value":{"kind":"Variable","name":{"kind":"Name","value":"locale"}}},{"kind":"Argument","name":{"kind":"Name","value":"region"},"value":{"kind":"Variable","name":{"kind":"Name","value":"region"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"utmSource"}},{"kind":"Field","name":{"kind":"Name","value":"recommendations"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"count"},"value":{"kind":"Variable","name":{"kind":"Name","value":"count"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tileId"}},{"kind":"Field","name":{"kind":"Name","value":"corpusItem"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"excerpt"}},{"kind":"Field","name":{"kind":"Name","value":"imageUrl"}},{"kind":"Field","name":{"kind":"Name","value":"publisher"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"timeToRead"}}]}}]}}]}}]}}]} as unknown as DocumentNode<NewTabRecommendationsQuery, NewTabRecommendationsQueryVariables>;

--- a/src/generated/openapi/types.ts
+++ b/src/generated/openapi/types.ts
@@ -113,6 +113,8 @@ export interface components {
       publisher: string;
       /** @description The primary image for a Recommendation. */
       imageUrl: string;
+      /** @description Article read time in minutes */
+      timeToRead?: number;
     };
     LegacyFeedItem: {
       id: number;
@@ -122,6 +124,7 @@ export interface components {
       domain: string;
       image_src: string;
       raw_image_src: string;
+      time_to_read?: number;
     };
     LegacySettings: {
       spocsPerNewTabs?: number;

--- a/src/graphql-proxy/recommendations/Recommendations.graphql
+++ b/src/graphql-proxy/recommendations/Recommendations.graphql
@@ -9,6 +9,7 @@ query NewTabRecommendations($locale: String!, $region: String, $count: Int) {
         publisher
         title
         url
+        timeToRead
       }
     }
   }

--- a/src/graphql-proxy/recommendations/__mocks__/recommendations.ts
+++ b/src/graphql-proxy/recommendations/__mocks__/recommendations.ts
@@ -10,6 +10,7 @@ import common from '../../__mocks__/common';
 
 import { NewTabRecommendationsQuery } from '../../../generated/graphql/types';
 import { RecommendationsParameters } from '../recommendations';
+import { GraphRecommendation } from '../../../api/desktop/recommendations/response';
 
 /**
  * faker locales do not match our own, map ours to faker locales
@@ -25,22 +26,43 @@ const fakerLocales = {
   it: 'it',
 };
 
+/**
+ *
+ * @param hasTimeToRead If true, timeToRead is set to [1, 9], otherwise it's undefined.
+ */
+const fakeRecommendation = (hasTimeToRead = true): GraphRecommendation => {
+  const recommendationWithoutTimeToRead: GraphRecommendation = {
+    __typename: 'CorpusRecommendation',
+    tileId: faker.datatype.number(),
+    corpusItem: {
+      excerpt: common.itemExcerpt(),
+      imageUrl: common.itemUrl(),
+      publisher: common.itemDomain(),
+      title: common.itemTitle(),
+      url: common.itemUrl(),
+    },
+  };
+
+  return hasTimeToRead
+    ? {
+        ...recommendationWithoutTimeToRead,
+        corpusItem: {
+          ...recommendationWithoutTimeToRead.corpusItem,
+          timeToRead: faker.datatype.number({ min: 1, max: 9 }),
+        },
+      }
+    : recommendationWithoutTimeToRead;
+};
+
 const fakeRecommendations = (
   count
 ): NewTabRecommendationsQuery['newTabSlate']['recommendations'] => {
   return Array(count)
     .fill(0)
-    .map(() => ({
-      __typename: 'CorpusRecommendation',
-      tileId: faker.datatype.number(),
-      corpusItem: {
-        excerpt: common.itemExcerpt(),
-        imageUrl: common.itemUrl(),
-        publisher: common.itemDomain(),
-        title: common.itemTitle(),
-        url: common.itemUrl(),
-      },
-    }));
+    .map((value, index) =>
+      // Add timeToRead only for even numbered recommendations.
+      fakeRecommendation(index % 2 === 0)
+    );
 };
 
 const recommendations = async ({

--- a/src/graphql-proxy/recommendations/__mocks__/recommendations.ts
+++ b/src/graphql-proxy/recommendations/__mocks__/recommendations.ts
@@ -43,17 +43,17 @@ const fakeRecommendation = (hasTimeToRead = true): GraphRecommendation => {
     },
   };
 
-  if (hasTimeToRead) {
-    return {
-      ...recommendationWithoutTimeToRead,
-      corpusItem: {
-        ...recommendationWithoutTimeToRead.corpusItem,
-        timeToRead: faker.datatype.number({ min: 1, max: 9 }),
-      },
-    };
-  } else {
+  if (!hasTimeToRead) {
     return recommendationWithoutTimeToRead;
   }
+
+  return {
+    ...recommendationWithoutTimeToRead,
+    corpusItem: {
+      ...recommendationWithoutTimeToRead.corpusItem,
+      timeToRead: faker.datatype.number({ min: 1, max: 9 }),
+    },
+  };
 };
 
 const fakeRecommendations = (

--- a/src/graphql-proxy/recommendations/__mocks__/recommendations.ts
+++ b/src/graphql-proxy/recommendations/__mocks__/recommendations.ts
@@ -43,15 +43,17 @@ const fakeRecommendation = (hasTimeToRead = true): GraphRecommendation => {
     },
   };
 
-  return hasTimeToRead
-    ? {
-        ...recommendationWithoutTimeToRead,
-        corpusItem: {
-          ...recommendationWithoutTimeToRead.corpusItem,
-          timeToRead: faker.datatype.number({ min: 1, max: 9 }),
-        },
-      }
-    : recommendationWithoutTimeToRead;
+  if (hasTimeToRead) {
+    return {
+      ...recommendationWithoutTimeToRead,
+      corpusItem: {
+        ...recommendationWithoutTimeToRead.corpusItem,
+        timeToRead: faker.datatype.number({ min: 1, max: 9 }),
+      },
+    };
+  } else {
+    return recommendationWithoutTimeToRead;
+  }
 };
 
 const fakeRecommendations = (


### PR DESCRIPTION
## Goal
Add time_to_read and timeToRead respectively to the old and new recommendation endpoint.

## Implementation Decisions
- Remove the region enum again. This change accidentally got reverted in https://github.com/Pocket/firefox-api-proxy/pull/55.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/DIS-852

## QA
As part of the QA steps in [#908](https://github.com/Pocket/parser-graphql-wrapper/pull/908) we simulated a Parser outage, and checked that recommendations continue to be returned successfully. When firefox-api-proxy is deployed to Pocket-Dev it requests production recommendations, so we can only QA the scenario where the Parser is available for this PR.

### [/v3/firefox/global-recs en-GB](https://firefox-api-proxy.getpocket.dev/v3/firefox/global-recs?count=30&locale_lang=en-GB&region=GB&version=3&consumer_key=94110-6d5ff7a89d72c869766af0e0)

- [x] Most recommendations have time_to_read with an integer value
- [x] `time_to_read` is missing for a small number of the recommendations

### [/desktop/v1/recommendations fr-FR](https://firefox-api-proxy.getpocket.dev/desktop/v1/recommendations?locale=fr&region=FR&count=30&consumer_key=94110-6d5ff7a89d72c869766af0e0)

- [x] Most recommendations have time_to_read with an integer value
- [x] `time_to_read` is missing for a small number of the recommendations