### PR TITLE
fix: [MC-17] set region to null if undefined

### DIFF
--- a/src/api/desktop/recommendations/inputs.spec.ts
+++ b/src/api/desktop/recommendations/inputs.spec.ts
@@ -88,6 +88,12 @@ describe('input.ts recommendations query parameters', () => {
       );
     });
 
+    it('sets region to null if no default is provided', () => {
+      const res = setDefaultsAndCoerceTypes({});
+      // validation should return an error in this case, validating defaults though
+      expect(res.region).toStrictEqual(null);
+    });
+
     it('region is case insensitive', () => {
       const params = {
         count: faker.datatype.number({ min: 1, max: 30 }),

--- a/src/api/desktop/recommendations/inputs.ts
+++ b/src/api/desktop/recommendations/inputs.ts
@@ -112,6 +112,7 @@ export const setDefaultsAndCoerceTypes = (
   const withDefaults = {
     // specify defaults here
     count: '30',
+    region: null,
     // spread to overwrite defaults with provided values
     ...stringParams,
   };

--- a/src/api/v3/inputs.spec.ts
+++ b/src/api/v3/inputs.spec.ts
@@ -32,6 +32,12 @@ describe('input.ts recommendations query parameters', () => {
         count: 20,
       });
     });
+
+    it('sets region to null if no default is provided', () => {
+      const res = setDefaultsAndCoerceTypes({});
+      // validation should return an error in this case, validating defaults though
+      expect(res.region).toStrictEqual(null);
+    });
   });
 
   describe('handleQueryParameters', () => {

--- a/src/api/v3/inputs.ts
+++ b/src/api/v3/inputs.ts
@@ -44,7 +44,7 @@ export const setDefaultsAndCoerceTypes = (
 ): PreValidatedQueryParameters => {
   return {
     count: parseInt(stringParams.count ?? '20', 10),
-    region: stringParams.region,
+    region: stringParams.region ?? null,
     locale: stringParams.locale_lang,
   };
 };


### PR DESCRIPTION
## Goal
During QA we discovered that Firefox iOS does not send a region when requesting recommendations, and this results in an internal server error. Region was made optional in Firefox API proxy, but it a required _nullable_ argument in the GraphQL query.

Request: https://firefox-api-proxy.cdn.mozilla.net/v3/firefox/global-recs?count=11&locale_lang=en-US&version=3&consumer_key=69690-c6b71598380d67d6fbb91165

Response:
```
{
  "errors": [
    {
      "id": "5eb9b295-1b8f-4d39-9337-6e91332d1029",
      "status": "502",
      "title": "Bad Gateway",
      "source": {
        "graphQLError": "Internal server error: {\"response\":{\"errors\":[{\"message\":\"Internal server error\",\"path\":[\"newTabSlate\"],\"extensions\":{\"code\":\"INTERNAL_SERVER_ERROR\"}}],\"data\":null,\"status\":200,\"headers\":{}},\"request\":{\"query\":\"query NewTabRecommendations($locale: String!, $region: String, $count: Int) {\\n newTabSlate(locale: $locale, region: $region) {\\n utmSource\\n recommendations(count: $count) {\\n tileId\\n corpusItem {\\n excerpt\\n imageUrl\\n publisher\\n title\\n url\\n timeToRead\\n }\\n }\\n }\\n}\",\"variables\":{\"count\":11,\"locale\":\"en-US\"}}}"
      }
    }
  ]
}
```

## Todo
- [x] Tested locally with http://localhost:4028/v3/firefox/global-recs?count=11&locale_lang=en-US&version=3&consumer_key=69690-c6b71598380d67d6fbb91165
- [x] Tested locally with http://localhost:4028/desktop/v1/recommendations?locale=fr&count=30&consumer_key=94110-6d5ff7a89d72c869766af0e0

## Implementation Decisions
- For parity, I also prevented the 502 error in the endpoint used by desktop.

## References

JIRA ticket:
* https://mozilla-hub.atlassian.net/browse/MC-17

iOS QA ticket:
* https://mozilla-hub.atlassian.net/browse/FXIOS-7056