### PR TITLE
feat(cache-control): [MC-30] Change max-age to 900

### DIFF
--- a/src/api/desktop/recommendations/index.ts
+++ b/src/api/desktop/recommendations/index.ts
@@ -16,7 +16,7 @@ router.get(
   '/v1/recommendations',
   // request must include a consumer
   ConsumerKeyHandler,
-  CacheControlHandler('public, max-age=1800', config),
+  CacheControlHandler('public, max-age=900', config),
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const variables = handleQueryParameters(req.query);

--- a/src/api/desktop/recommendations/recommendations.spec.ts
+++ b/src/api/desktop/recommendations/recommendations.spec.ts
@@ -74,7 +74,7 @@ describe('recommendations API server', () => {
       .get(`/desktop/v1/recommendations?${params.toString()}`)
       .set(authHeaders)
       .send()
-      .expect('Cache-control', 'public, max-age=1800'); // assert the Cache-control header is overwritten by the /v1/recommendations route
+      .expect('Cache-control', 'public, max-age=900'); // assert the Cache-control header is overwritten by the /v1/recommendations route
 
     expect(res.status).toEqual(200);
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -14,7 +14,7 @@ router.use(
   WebSessionAuthHandler,
   // set Cache-control headers on all routes
   // this can be overwritten on downstream routes with another handler
-  CacheControlHandler('private, max-age=1800', config),
+  CacheControlHandler('private, max-age=900', config),
   // register Desktop sub-router
   Desktop
 );
@@ -26,7 +26,7 @@ router.use(
   WebSessionAuthHandler,
   // set Cache-control headers on all routes
   // this can be overwritten on downstream routes with another handler
-  CacheControlHandler('private, max-age=1800', config),
+  CacheControlHandler('private, max-age=900', config),
   // register legacy v3 sub-router
   V3
 );

--- a/src/api/lib/cacheControlHandler.spec.ts
+++ b/src/api/lib/cacheControlHandler.spec.ts
@@ -22,7 +22,7 @@ describe('CacheControlHandler', () => {
     const config = getEnvironmentConfig('development');
 
     const app = express();
-    app.use(CacheControlHandler('private, max-age=1800', config));
+    app.use(CacheControlHandler('private, max-age=900', config));
     app.get('/', (req, res) => {
       res.status(200).json({ yay: true });
     });
@@ -36,7 +36,7 @@ describe('CacheControlHandler', () => {
   it('sets Cache-control header for other environments', async () => {
     const config = getEnvironmentConfig('production');
 
-    const headerValue = 'private, max-age=1800';
+    const headerValue = 'private, max-age=900';
 
     const app = express();
     app.use(CacheControlHandler(headerValue, config));
@@ -53,8 +53,8 @@ describe('CacheControlHandler', () => {
   it('the closest handler to route implementation sets Cache-control header if multiple exist', async () => {
     const config = getEnvironmentConfig('production');
 
-    const headerValue1 = 'private, max-age=1800';
-    const headerValue2 = 'max-age=1800';
+    const headerValue1 = 'private, max-age=900';
+    const headerValue2 = 'max-age=900';
 
     const app = express();
     app.use(CacheControlHandler(headerValue1, config));

--- a/src/api/v3/index.ts
+++ b/src/api/v3/index.ts
@@ -16,7 +16,7 @@ router.get(
   '/firefox/global-recs',
   // request must include a consumer
   ConsumerKeyHandler,
-  CacheControlHandler('public, max-age=1800', config),
+  CacheControlHandler('public, max-age=900', config),
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const variables = handleQueryParameters(req.query);

--- a/src/api/v3/recommendations.spec.ts
+++ b/src/api/v3/recommendations.spec.ts
@@ -60,7 +60,7 @@ describe('v3 legacy recommendations API server', () => {
     const res = await request(app)
       .get(`/v3/firefox/global-recs?${params.toString()}`)
       .send()
-      .expect('Cache-control', 'public, max-age=1800'); // assert the Cache-control header is overwritten by the global-recs route
+      .expect('Cache-control', 'public, max-age=900'); // assert the Cache-control header is overwritten by the global-recs route
 
     expect(res.status).toEqual(200);
 


### PR DESCRIPTION
## Goal
Match the cache-control duration of Firefox API Proxy to the legacy endpoint, which used 900 seconds. A lower cache duration can result in a higher click-through rate, because our feedback loop is faster.

## References

JIRA ticket:
* [MC-30](https://mozilla-hub.atlassian.net/jira/software/c/projects/MC/boards/720?modal=detail&selectedIssue=MC-30&assignee=64065e8893cf2599462fe21d)

Endpoints:
- [old Firefox recommendation endpoint](https://getpocket.com/v3/firefox/global-recs?count=30&locale_lang=en-US&region=US&version=3&consumer_key=94110-6d5ff7a89d72c869766af0e0) responds with `cache-control: s-maxage=900`
- [Firefox Proxy API responds with](https://getpocket.cdn.mozilla.net/v3/firefox/global-recs?count=20&locale_lang=de-DE&region=DE&version=3&consumer_key=69688-0187b8205b7a75b05d897e97) responds with `cache-control: public,max-age=1800,public`