### PR TITLE
feat(newtab): [MC-121] Disable auth for recommendations

### DIFF
--- a/src/api/desktop/recommendations/index.ts
+++ b/src/api/desktop/recommendations/index.ts
@@ -6,8 +6,6 @@ import { GraphQLErrorHandler } from '../../error/graphQLErrorHandler';
 import { handleQueryParameters } from './inputs';
 import { BFFFxError } from '../../../bfffxError';
 import Recommendations from '../../../graphql-proxy/recommendations/recommendations';
-import { forwardHeadersMiddleware } from '../../../graphql-proxy/lib/client';
-import { NewTabRecommendationsQueryVariables } from '../../../generated/graphql/types';
 import { RecommendationsResponse, responseTransformer } from './response';
 
 const router = express.Router();
@@ -25,12 +23,7 @@ router.get(
         return next(variables);
       }
 
-      const graphRes = await Recommendations({
-        auth: req.auth,
-        consumer_key: req.consumer_key,
-        forwardHeadersMiddleware: forwardHeadersMiddleware(res),
-        variables: variables as NewTabRecommendationsQueryVariables,
-      });
+      const graphRes = await Recommendations(variables);
 
       res.json(responseTransformer(graphRes) as RecommendationsResponse);
     } catch (error) {

--- a/src/api/desktop/recommendations/recommendations.spec.ts
+++ b/src/api/desktop/recommendations/recommendations.spec.ts
@@ -5,7 +5,6 @@ import RecommendationsMock from '../../../graphql-proxy/recommendations/__mocks_
 
 import config from '../../../config';
 import { buildBFFFxServer } from '../../../bfffxServer';
-import { WebAuth } from '../../../auth/types';
 
 import { components } from '../../../generated/openapi/types';
 type Recommendation = components['schemas']['Recommendation'];
@@ -22,8 +21,6 @@ type Recommendation = components['schemas']['Recommendation'];
 const { app } = buildBFFFxServer();
 
 const CONSUMER_KEY = 'fakeConsumerKey';
-const buildGraphUrl = () =>
-  `${config.app.graphGatewayUrl}?consumer_key=${CONSUMER_KEY}&enable_cors=1`;
 
 // generic auth cookies
 const cookies = {
@@ -47,16 +44,12 @@ describe('recommendations API server', () => {
 
   it('transforms graphql responses to server responses', async () => {
     const mockResponse = await RecommendationsMock({
-      // auth components and middlewares are unimportant to mocks,
-      // just mock them
-      auth: { junk: 'junk' } as unknown as WebAuth,
-      consumer_key: 'junkConsumerKey',
-      forwardHeadersMiddleware: () => null,
-      // provide real variables
-      variables: { count: 1, locale: 'it', region: 'IT' },
+      count: 1,
+      locale: 'it',
+      region: 'IT',
     });
 
-    fetchMock.mock(buildGraphUrl(), {
+    fetchMock.mock(config.app.clientApiGraphGatewayUrl, {
       status: 200,
       body: {
         data: mockResponse,

--- a/src/api/desktop/recommendations/response.spec.ts
+++ b/src/api/desktop/recommendations/response.spec.ts
@@ -3,7 +3,6 @@ import Ajv, { DefinedError } from 'ajv';
 import OpenApiSpec from '../../OpenAPISpec';
 import Recommendations from '../../../graphql-proxy/recommendations/recommendations';
 import { appendUtmSource, responseTransformer } from './response';
-import { WebAuth } from '../../../auth/types';
 
 jest.mock('../../../graphql-proxy/recommendations/recommendations');
 
@@ -29,17 +28,9 @@ describe('response', () => {
     it('handles happy path results', async () => {
       // the default mock is happy path, ensure this is handled
       const graphResponse = await Recommendations({
-        // auth components and middlewares are unimportant to mocks
-        // just mock them
-        auth: { junk: 'junk' } as unknown as WebAuth,
-        consumer_key: 'junkConsumerKey',
-        forwardHeadersMiddleware: () => null,
-        // provide real variables
-        variables: {
-          count: 30,
-          locale: 'fr',
-          region: 'FR',
-        },
+        count: 30,
+        locale: 'fr',
+        region: 'FR',
       });
 
       const res = responseTransformer(graphResponse);

--- a/src/api/v3/index.ts
+++ b/src/api/v3/index.ts
@@ -6,8 +6,6 @@ import { GraphQLErrorHandler } from '../error/graphQLErrorHandler';
 import { handleQueryParameters } from './inputs';
 import { BFFFxError } from '../../bfffxError';
 import Recommendations from '../../graphql-proxy/recommendations/recommendations';
-import { forwardHeadersMiddleware } from '../../graphql-proxy/lib/client';
-import { NewTabRecommendationsQueryVariables } from '../../generated/graphql/types';
 import { GlobalRecsResponse, responseTransformer } from './response';
 
 const router = express.Router();
@@ -25,12 +23,7 @@ router.get(
         return next(variables);
       }
 
-      const graphRes = await Recommendations({
-        auth: req.auth,
-        consumer_key: req.consumer_key,
-        forwardHeadersMiddleware: forwardHeadersMiddleware(res),
-        variables: variables as NewTabRecommendationsQueryVariables,
-      });
+      const graphRes = await Recommendations(variables);
 
       res.json(responseTransformer(graphRes) as GlobalRecsResponse);
     } catch (error) {

--- a/src/api/v3/recommendations.spec.ts
+++ b/src/api/v3/recommendations.spec.ts
@@ -5,7 +5,6 @@ import RecommendationsMock from '../../graphql-proxy/recommendations/__mocks__/r
 
 import config from '../../config';
 import { buildBFFFxServer } from '../../bfffxServer';
-import { WebAuth } from '../../auth/types';
 
 import { components } from '../../generated/openapi/types';
 type LegacyFeedItem = components['schemas']['LegacyFeedItem'];
@@ -22,8 +21,6 @@ type LegacyFeedItem = components['schemas']['LegacyFeedItem'];
 const { app } = buildBFFFxServer();
 
 const CONSUMER_KEY = 'fakeConsumerKey';
-const buildGraphUrl = () =>
-  `${config.app.graphGatewayUrl}?consumer_key=${CONSUMER_KEY}&enable_cors=1`;
 
 describe('v3 legacy recommendations API server', () => {
   beforeEach(() => {
@@ -33,16 +30,12 @@ describe('v3 legacy recommendations API server', () => {
 
   it('transforms graphql responses to server responses', async () => {
     const mockResponse = await RecommendationsMock({
-      // auth components and middlewares are unimportant to mocks,
-      // just mock them
-      auth: { junk: 'junk' } as unknown as WebAuth,
-      consumer_key: 'junkConsumerKey',
-      forwardHeadersMiddleware: () => null,
-      // provide real variables
-      variables: { count: 1, locale: 'it', region: 'IT' },
+      count: 1,
+      locale: 'it',
+      region: 'IT',
     });
 
-    fetchMock.mock(buildGraphUrl(), {
+    fetchMock.mock(config.app.clientApiGraphGatewayUrl, {
       status: 200,
       body: {
         data: mockResponse,
@@ -51,7 +44,7 @@ describe('v3 legacy recommendations API server', () => {
     });
 
     const params = new URLSearchParams();
-    params.append('consumer_key', CONSUMER_KEY);
+    params.append('consumer_key', CONSUMER_KEY); // No longer used for auth
     params.append('version', '3');
     params.append('count', '1');
     params.append('locale_lang', 'it');

--- a/src/api/v3/response.spec.ts
+++ b/src/api/v3/response.spec.ts
@@ -3,7 +3,6 @@ import Ajv, { DefinedError } from 'ajv';
 import OpenApiSpec from '../OpenAPISpec';
 import Recommendations from '../../graphql-proxy/recommendations/recommendations';
 import { responseTransformer } from './response';
-import { WebAuth } from '../../auth/types';
 
 jest.mock('../../graphql-proxy/recommendations/recommendations');
 
@@ -29,17 +28,9 @@ describe('response', () => {
     it('handles happy path results', async () => {
       // the default mock is happy path, ensure this is handled
       const graphResponse = await Recommendations({
-        // auth components and middlewares are unimportant to mocks
-        // just mock them
-        auth: { junk: 'junk' } as unknown as WebAuth,
-        consumer_key: 'junkConsumerKey',
-        forwardHeadersMiddleware: () => null,
-        // provide real variables
-        variables: {
-          count: 30,
-          locale: 'fr',
-          region: 'FR',
-        },
+        count: 30,
+        locale: 'fr',
+        region: 'FR',
       });
 
       const res = responseTransformer(graphResponse);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,8 +4,12 @@ export default {
     environment: process.env.NODE_ENV || 'development',
     defaultMaxAge: 86400,
     port: 4028,
+    clientApiName: 'firefox-api-proxy',
     graphGatewayUrl:
       process.env.GRAPH_GATEWAY_URL || 'https://getpocket.com/graphql',
+    clientApiGraphGatewayUrl:
+      process.env.CLIENT_API_GRAPH_GATEWAY_URL ||
+      'https://client-api.getpocket.com',
   },
   sentry: {
     dsn: process.env.SENTRY_DSN || '',

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,7 +4,7 @@ export default {
     environment: process.env.NODE_ENV || 'development',
     defaultMaxAge: 86400,
     port: 4028,
-    clientApiName: 'firefox-api-proxy',
+    clientName: 'firefox-api-proxy',
     graphGatewayUrl:
       process.env.GRAPH_GATEWAY_URL || 'https://getpocket.com/graphql',
     clientApiGraphGatewayUrl:

--- a/src/graphql-proxy/lib/client.ts
+++ b/src/graphql-proxy/lib/client.ts
@@ -48,7 +48,7 @@ export const webProxyClient = (
       fetch,
       // baseline headers for all requests
       headers: {
-        'apollographql-client-name': config.app.clientApiName,
+        'apollographql-client-name': config.app.clientName,
       },
       responseMiddleware: forwardHeadersMiddleware,
     }

--- a/src/graphql-proxy/lib/client.ts
+++ b/src/graphql-proxy/lib/client.ts
@@ -48,7 +48,7 @@ export const webProxyClient = (
       fetch,
       // baseline headers for all requests
       headers: {
-        'apollographql-client-name': 'firefox-api-proxy',
+        'apollographql-client-name': config.app.clientApiName,
       },
       responseMiddleware: forwardHeadersMiddleware,
     }

--- a/src/graphql-proxy/recommendations/__mocks__/recommendations.ts
+++ b/src/graphql-proxy/recommendations/__mocks__/recommendations.ts
@@ -8,8 +8,10 @@ import { faker } from '@faker-js/faker';
 
 import common from '../../__mocks__/common';
 
-import { NewTabRecommendationsQuery } from '../../../generated/graphql/types';
-import { RecommendationsParameters } from '../recommendations';
+import {
+  NewTabRecommendationsQuery,
+  NewTabRecommendationsQueryVariables,
+} from '../../../generated/graphql/types';
 import { GraphRecommendation } from '../../../api/desktop/recommendations/response';
 
 /**
@@ -67,12 +69,9 @@ const fakeRecommendations = (
     );
 };
 
-const recommendations = async ({
-  auth,
-  consumer_key,
-  forwardHeadersMiddleware,
-  variables,
-}: RecommendationsParameters): Promise<NewTabRecommendationsQuery> => {
+const recommendations = async (
+  variables: NewTabRecommendationsQueryVariables
+): Promise<NewTabRecommendationsQuery> => {
   // set faker locale based on variables
   // default to english if unrecognized, roughly matches graph behavior selecting locale.
   const fakerLocale = fakerLocales[variables.locale.toLowerCase()] ?? 'en';

--- a/src/graphql-proxy/recommendations/recommendations.ts
+++ b/src/graphql-proxy/recommendations/recommendations.ts
@@ -1,17 +1,10 @@
-import { webProxyClient } from '../lib/client';
-
 import {
   NewTabRecommendationsDocument,
   NewTabRecommendationsQuery,
   NewTabRecommendationsQueryVariables,
 } from '../../generated/graphql/types';
-import { ClientParameters } from '../types';
-
-/**
- * recommendations.ts GraphQL client request parameters
- */
-export type RecommendationsParameters =
-  ClientParameters<NewTabRecommendationsQueryVariables>;
+import { GraphQLClient } from 'graphql-request';
+import config from '../../config';
 
 /**
  * This client performs the query specified in Recommendations.graphql, utilizing
@@ -22,14 +15,16 @@ export type RecommendationsParameters =
  * This client does not validate inputs. It is expected that route handlers will
  * validate and transform any URL parameters, query parameters, and payloads.
  */
-const Recommendations = async ({
-  auth,
-  consumer_key,
-  forwardHeadersMiddleware,
-  variables,
-}: RecommendationsParameters) => {
-  const client = webProxyClient(consumer_key, forwardHeadersMiddleware);
-  auth.authenticateClient(client);
+const Recommendations = async (
+  variables: NewTabRecommendationsQueryVariables
+) => {
+  const client = new GraphQLClient(config.app.clientApiGraphGatewayUrl, {
+    fetch,
+    // baseline headers for all requests
+    headers: {
+      'apollographql-client-name': config.app.clientApiName,
+    },
+  });
 
   return client.request<
     NewTabRecommendationsQuery,

--- a/src/graphql-proxy/recommendations/recommendations.ts
+++ b/src/graphql-proxy/recommendations/recommendations.ts
@@ -22,7 +22,7 @@ const Recommendations = async (
     fetch,
     // baseline headers for all requests
     headers: {
-      'apollographql-client-name': config.app.clientApiName,
+      'apollographql-client-name': config.app.clientName,
     },
   });
 


### PR DESCRIPTION
## Goal
Stop 403 errors from being returned on requests for New Tab recommendations, by disabling auth on these endpoints. These recommendations are the same for all users. There is no need for authentication on these endpoints.

## How to test
1. `npm run start:dev`
2. http://localhost:4028/desktop/v1/recommendations?locale=fr&count=30&consumer_key=foobar
3. http://localhost:4028/v3/firefox/global-recs?count=30&locale_lang=en-US&region=US&version=3&consumer_key=foobar

## I'd love feedback/perspectives on:
Documentation: What (if any) documentation should we add, and where?

## Implementation Decisions
- I applied the change to both old (/v3/firefox/global-recs) and new (/desktop/v1/recommendations) recommendation endpoint.
- I did not change the OpenAPI schema. For now, clients still require a consumer_key. A possible use-case is to attribute requests. I'm open to whether this is a good idea or not, but didn't want to block this PR on it.

## References

JIRA ticket:
* https://mozilla-hub.atlassian.net/browse/MC-121

Documentation:
* [Post-mortem doc](https://docs.google.com/document/d/1EwCjt5rivBDFt1XaBig0atDSvycKD6_HcOeqiuLyNnQ/edit)
* [RRA for firefox-api-proxy](https://docs.google.com/document/d/1y9IH9NqfiSgltazZoP3GKsPCQRTr2FldY1xLyITBZK4/edit#heading=h.ufs6i6416jwo)
* [Incident Slack thread](https://mozilla.slack.com/archives/C05EAHBM35Z/p1695141302365519)
