### PR TITLE
feat(waf): [MC-147] Increase rate limit

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -323,8 +323,11 @@ class Stack extends TerraformStack {
     AWS and GCP. Leaving this limit relatively permissive to allow devs and testing
     infrastructure to hit firefox-api-proxy directly bypassing caching.
 
-    If needed, this limit can be decreased. All firefox client traffic should be though
-    the CDN soon (still a nightly release hitting this service directly floating around).
+    https://docs.google.com/document/d/1EwCjt5rivBDFt1XaBig0atDSvycKD6_HcOeqiuLyNnQ
+    Between 2023-09-11 and 2023-09-25 there was a increase in requests to 3000 RPM
+    hitting the backend. The spike seemed to be coming from old ESR versins running
+    on corporate networks, going through our CDN as expected. We did not see any sign
+    of malicious intent. We successfully completed a load test for 4000 RPM in MC-135.
     */
     const globalRateLimitRule = <Wafv2WebAclRule>{
       name: 'GlobalRateLimit',
@@ -332,7 +335,7 @@ class Stack extends TerraformStack {
       action: { block: {} },
       statement: {
         rateBasedStatement: {
-          limit: 1000,
+          limit: 4000,
           aggregateKeyType: 'IP',
         },
       },


### PR DESCRIPTION
## Goal
Prevent request rate increases for New Tab recommendation from getting IP rate-limited. We are not sure whether this caused any user-impact, but it did cost us a lot of time to investigate. As far as we can tell, it was coming from old ESR Firefox clients, and there was no bad intent.

A [load test](https://mozilla-hub.atlassian.net/browse/MC-135) indicates that the newTabSlate query is able to handle this increased load.

![image](https://github.com/Pocket/firefox-api-proxy/assets/1547251/b71a888a-8c4b-4e5a-8033-0e8af10b82a6)


## Implementation decisions
- A rate limit increase seems the simplest way to prevent similar issues. I also added an item to [our road map](https://mozilla-hub.atlassian.net/wiki/spaces/MozSocial/pages/369328240/Content+-+Technical+Roadmap#Proposals) for further improvements.

## References

JIRA ticket:
* [Rate limit increase](https://mozilla-hub.atlassian.net/browse/MC-147)
* [Load test](https://mozilla-hub.atlassian.net/browse/MC-135)

Documentation:
* [Post-mortem doc](https://docs.google.com/document/d/1EwCjt5rivBDFt1XaBig0atDSvycKD6_HcOeqiuLyNnQ)
