### PR TITLE
feat: rename id to recommendationId

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -134,7 +134,7 @@ components:
           description: Constant identifier for Recommendation type objects.
           enum:
             - Recommendation
-        id:
+        recommendationId:
           type: string
           description: String identifier for the Recommendation. This value is expected to be different on each request.
         tileId:

--- a/src/api/desktop/recommendations/recommendations.spec.ts
+++ b/src/api/desktop/recommendations/recommendations.spec.ts
@@ -79,7 +79,7 @@ describe('recommendations API server', () => {
     // not checking exhaustively, just some general mapping
     // response.spec.ts is responsible for keeping these in sync.
     expect(recommendation.__typename).toEqual('Recommendation');
-    expect(recommendation.id).toEqual(
+    expect(recommendation.recommendationId).toEqual(
       mockResponse.newTabSlate.recommendations[0].id
     );
     expect(recommendation.tileId).toEqual(

--- a/src/api/desktop/recommendations/response.ts
+++ b/src/api/desktop/recommendations/response.ts
@@ -46,7 +46,7 @@ export const mapRecommendation = (
 ): Recommendation => {
   const recommendationToReturn: Recommendation = {
     __typename: 'Recommendation',
-    id: recommendation.id,
+    recommendationId: recommendation.id,
     tileId: recommendation.tileId,
     url: appendUtmSource(
       recommendation.corpusItem.url,

--- a/src/generated/openapi/types.ts
+++ b/src/generated/openapi/types.ts
@@ -102,7 +102,7 @@ export interface components {
        */
       __typename: "Recommendation";
       /** @description String identifier for the Recommendation. This value is expected to be different on each request. */
-      id?: string;
+      recommendationId?: string;
       /**
        * @deprecated 
        * @description Numerical identifier for the Recommendation. This is specifically a number for Fx client and Mozilla data pipeline compatibility. This property will continue to be present because Firefox clients depend on it, but downstream users should use the recommendation id instead when available.


### PR DESCRIPTION
## Goal
Be more consistent with naming between [Glean](https://bugzilla.mozilla.org/show_bug.cgi?id=1854245) and the API.

## I'd love feedback/perspectives on:
Is this naming better? The plan is to also apply the renaming to the MoSo content feed API.

## Deployment steps
- [ ] Sync with Chutten to check that this attribute is not yet used in Nightly. It doesn't look like [the Firefox change](https://phabricator.services.mozilla.com/D190980) is reviewed yet.

## References

JIRA ticket:
* https://mozilla-hub.atlassian.net/browse/MC-204

Glean Bugzilla bug:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1854245

Slack thread where naming was discussed:
* https://mozilla.slack.com/archives/C05EVRU1U1X/p1696875274478699

Firefox change:
* https://phabricator.services.mozilla.com/D190980