### PR TITLE
chore(infra): [MC-1418] Update CircleCI orb to new version with current images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  pocket: pocket/circleci-orbs@2.2.2
+  pocket: pocket/circleci-orbs@2.2.3
   backstage-entity-validator: roadiehq/backstage-entity-validator@0.4.2
 
 # Workflow shortcuts


### PR DESCRIPTION
## Goal

Keep ahead of CircleCI deprecating old Linux images.

## References

JIRA ticket:
* https://mozilla-hub.atlassian.net/browse/MC-1418