### PR TITLE
fix(saves): update inputs to allow overzealous counts

### DIFF
--- a/src/api/desktop/recent-saves/inputs.ts
+++ b/src/api/desktop/recent-saves/inputs.ts
@@ -40,8 +40,14 @@ export const setDefaultsAndCoerceTypes = (
     ...stringParams,
   };
 
+  let count = parseInt(withDefaults.count, 10);
+  if (count > 20) {
+    // versions of Firefox are asking for 88 items, so we'll allow up to 20
+    count = 20;
+  }
+
   return {
-    count: parseInt(withDefaults.count, 10),
+    count: count,
   };
 };
 

--- a/src/api/desktop/recent-saves/inputs.ts
+++ b/src/api/desktop/recent-saves/inputs.ts
@@ -42,7 +42,8 @@ export const setDefaultsAndCoerceTypes = (
 
   let count = parseInt(withDefaults.count, 10);
   if (count > 20) {
-    // versions of Firefox are asking for 88 items, so we'll allow up to 20
+    // versions of Firefox are asking for 88 items, but this code used to reject anything above 20 for an unknown reason.
+    // so to maintain that logic we limit the count to 20 items if firefox asks for more.
     count = 20;
   }
 


### PR DESCRIPTION
## Goal

I noticed Firefox regular & nightly are request 88 items from recent saves and failing. This allows that input, but will bring it down to 20 so that it succeeds.